### PR TITLE
Headless CPA allows us to run on MacOS 64bit environments

### DIFF
--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -430,7 +430,7 @@ class CPAnalyst(wx.App):
 
         # The JVM has to be started after db.connect(), otherwise bus errors
         # occur on Mac OS X.
-        javabridge.start_vm(class_path=bioformats.JARS, run_headless=False)
+        javabridge.start_vm(class_path=bioformats.JARS, run_headless=True)
         javabridge.attach()
         javabridge.activate_awt()
 


### PR DESCRIPTION
CPA crushes for 64bits due to the Event Loop in MacOS. Running it in headless mode allows us to call CPA via CLI in MacOS (assuming we have all dependencies installed)