### PR TITLE
Fix segmentation fault when removing tiles

### DIFF
--- a/cpa/sortbin.py
+++ b/cpa/sortbin.py
@@ -222,7 +222,7 @@ class SortBin(wx.ScrolledWindow):
         for tile in self.Selection():
             self.tiles.remove(tile)
             self.sizer.Remove(tile)
-            tile.Destroy()
+            wx.CallAfter(tile.Destroy)
         self.UpdateSizer()
         self.UpdateQuantity()
     


### PR DESCRIPTION
When removing a tile, CPA crashes due to a segmentation fault because it is destroyed immediately.
The wxPython interface calls methods on a non existing tile.
Lee fixed it with a wx.CallAfter wrapper around the destroy method.