### PR TITLE
Fixing deleting bins, similar to issue #78

### DIFF
--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -589,7 +589,7 @@ class Classifier(wx.Frame):
                 self.obClassChoice.Select(0)
                 # Remove the bin
                 self.classified_bins_sizer.Remove(bin.parentSizer)
-                bin.Destroy()
+                wx.CallAfter(bin.Destroy)
                 self.classified_bins_panel.Layout()
                 break
         self.algorithm.UpdateBins([]);


### PR DESCRIPTION
When deleting a bin, we encounter the same as issue #78. Hence, I fixed it in the same way with a wx.CallAfter wrapper.