### PR TITLE
Make the Plate viewer tool resilient to white spaces in well names

### DIFF
--- a/cpa/datamodel.py
+++ b/cpa/datamodel.py
@@ -264,9 +264,10 @@ class DataModel(Singleton):
         
         res = db.execute('SELECT DISTINCT %s FROM %s '%(p.well_id, p.image_table))
         for r in res:
-            well = r[0].strip()
+            well = r[0]
             # Make sure all well entries match the naming format
             if type(well) == str:
+                well = well.strip()
                 assert re.match(well_re, well), 'Well "%s" did not match well naming format "%s"'%(r[0], p.well_format)
             elif type(well) in [int, long]:
                 if not p.well_format == '123':

--- a/cpa/datamodel.py
+++ b/cpa/datamodel.py
@@ -307,6 +307,7 @@ class DataModel(Singleton):
         '''returns the plate position tuple (row, col) corresponding to 
         the given well_name.
         '''
+        well_name = well_name.strip()
         if self.plate_map == {}:
             self.populate_plate_maps()
         if well_name in self.plate_map.keys():

--- a/cpa/datamodel.py
+++ b/cpa/datamodel.py
@@ -264,7 +264,7 @@ class DataModel(Singleton):
         
         res = db.execute('SELECT DISTINCT %s FROM %s '%(p.well_id, p.image_table))
         for r in res:
-            well = r[0]
+            well = r[0].strip()
             # Make sure all well entries match the naming format
             if type(well) == str:
                 assert re.match(well_re, well), 'Well "%s" did not match well naming format "%s"'%(r[0], p.well_format)


### PR DESCRIPTION
In my case, this change to datamodel.py was needed because in CellProfiler, I accidentally defined my well metadata regular expression as (notice the white space)

`(?P<Well> [A-P][0-9]{2})$`

hence causing the following error in cpa when launching the Plate Viewer tool:

```python
An error occurred in the program:
AssertionError: Well " A01" did not match well naming format "A01"

Traceback (most recent call last):
  File "CellProfiler-Analyst.py", line 262, in launch_plate_map_browser
  File "cpa\plateviewer.pyc", line 175, in __init__
  File "cpa\plateviewer.pyc", line 203, in AddPlateMap
  File "cpa\platemappanel.pyc", line 72, in __init__
  File "cpa\datamodel.pyc", line 310, in get_well_position_from_name
  File "cpa\datamodel.pyc", line 270, in populate_plate_maps
```
Rather than reprocessing all my data, I thought it would be quicker to hack datamodel.py to be resilient to extraneous whitespaces on either side of the well name. " A01", "A01 " and " A01 " all become valid well names with this change.

If you find this useful, feel free to merge.

Cheers,
Egor