### PR TITLE
import sys in cpa/profiling/plot_distances.py

### DIFF
--- a/cpa/profiling/plot_distances.py
+++ b/cpa/profiling/plot_distances.py
@@ -5,6 +5,7 @@ Plot distances between profiles.
 
 """
 
+import sys
 from optparse import OptionParser
 import numpy as np
 from scipy.spatial.distance import cdist
@@ -12,6 +13,7 @@ import matplotlib.pyplot as plt
 import pylab
 import cpa
 from .profiles import Profiles
+
 
 def plot_distances(profiles, output_group_name=None):
     if output_group_name:


### PR DESCRIPTION
__sys__ is used on lines 30 and 31 but it is never imported.

flake8 testing of https://github.com/CellProfiler/CellProfiler-Analyst on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```                                               ^
./cpa/profiling/plot_distances.py:28:25: F821 undefined name 'sys'
                print >>sys.stderr, 'Error: Input group %r contains images in %d output groups' % (key, len(set(groups)))
                        ^
./cpa/profiling/plot_distances.py:28:100: F821 undefined name 'key'
                print >>sys.stderr, 'Error: Input group %r contains images in %d output groups' % (key, len(set(groups)))
                                                                                                   ^
./cpa/profiling/plot_distances.py:29:17: F821 undefined name 'sys'
                sys.exit(1)
                ^
```