### PR TITLE
Resolve 29 undefined names found by flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.6  
+  allow_failures:
+    - python: 3.6
+install:
+  - pip install --upgrade pip
+  - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script: true  # pytest
+notifications:
+  email: false
+  slack:
+    secure: kDWVy90sDY+o3g0/ZTGX2D+PTbzhtd74Whe1AJHhcUDobTUzkch8GtY9eZxybZk4nga9lQxL6YeJ72SfBBEPaLzXcUMe0YcNaBydkQHcipKZn+Vcb8kf2FiZC6YwsUYfTvvH9MPLbkZOZvsNyd0h85z+hYMB8jHsq6Yn5gf79BA=
+    on_failure: always
+    on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ install:
   - pip install flake8
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # **temporarily** add --exit-zero to this first flake8 run
+  - flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: true  # pytest

--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -95,7 +95,6 @@ from cpa.cpatool import CPATool
 import inspect
 
 from cpa.icons import get_cpa_icon
-import cpa.dbconnect
 import cpa.multiclasssql
 # ---
 import wx
@@ -351,7 +350,7 @@ class MainGUI(wx.Frame):
         response = dlg.ShowModal()
         if response != wx.ID_YES:
             return
-        db = dbconnect.DBConnect.getInstance()
+        db = DBConnect.getInstance()
         db.execute('DROP TABLE IF EXISTS %s'%(p.link_tables_table))
         db.execute('DROP TABLE IF EXISTS %s'%(p.link_columns_table))
         db.Commit()
@@ -452,7 +451,7 @@ class CPAnalyst(wx.App):
 
         self.frame = MainGUI(p, None, size=(1000,-1))
 
-        db = cpa.dbconnect.DBConnect.getInstance()
+        db = DBConnect.getInstance()
         # Black magic: Bus errors occur on Mac OS X if we wait until
         # the JVM or the wx event look has started to connect. But it
         # has to be done after we have read the properties file. So we

--- a/cpa/boxplot.py
+++ b/cpa/boxplot.py
@@ -394,7 +394,7 @@ if __name__ == "__main__":
         # necessary in case other modal dialogs are up
         wx.GetApp().Exit()
         sys.exit()
-        afraser
+
     boxplot = BoxPlot(None)
     boxplot.Show()
     

--- a/cpa/datatable.py
+++ b/cpa/datatable.py
@@ -1,11 +1,11 @@
 # -*- Encoding: utf-8 -*-
+from cpa.dbconnect import DBConnect
 from datamodel import DataModel
 from properties import Properties
 from sys import stderr
 from tempfile import gettempdir
 from time import ctime, time
 #from wx.lib.embeddedimage import PyEmbeddedImage
-import dbconnect
 import imagetools
 import csv
 import logging
@@ -17,7 +17,7 @@ import wx
 import wx.grid
 
 dm = DataModel.getInstance()
-db = dbconnect.DBConnect.getInstance()
+db = DBConnect.getInstance()
 p = Properties.getInstance()
 
 ID_LOAD_CSV = wx.NewId()
@@ -644,7 +644,7 @@ if __name__ == "__main__":
     propsfile = sys.argv[2]
     
     p = Properties.getInstance()
-    db = dbconnect.DBConnect.getInstance()
+    db = DBConnect.getInstance()
     dm = DataModel.getInstance()
 
     p.LoadFile(propsfile)

--- a/cpa/datatable.py
+++ b/cpa/datatable.py
@@ -1,8 +1,8 @@
 # -*- Encoding: utf-8 -*-
+from cpa import dbconnect
 from cpa.dbconnect import DBConnect
 from datamodel import DataModel
 from properties import Properties
-from sys import stderr
 from tempfile import gettempdir
 from time import ctime, time
 #from wx.lib.embeddedimage import PyEmbeddedImage
@@ -11,7 +11,6 @@ import csv
 import logging
 import numpy as np
 import os
-import sys
 import weakref
 import wx
 import wx.grid

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -1609,7 +1609,7 @@ class DBConnect(Singleton):
     def CreateTempTableFromData(self, dtable, colnames, tablename, temporary=True):
         '''Creates and populates a temporary table in the database.
         '''
-        return CreateTableFromData(dtable, colnames, tablename, temporary=temporary)
+        return self.CreateTableFromData(dtable, colnames, tablename, temporary=temporary)
     
     def CreateTableFromData(self, dtable, colnames, tablename, temporary=False, coltypes=None):
         '''Creates and populates a table in the database.

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -1731,7 +1731,7 @@ class DBConnect(Singleton):
         nbins and bin_edges is a numpy array of size nbins + 1.
         """
         if ' ' in table_or_query:
-            table_clause = "(%s) as foo"%(query,)
+            table_clause = "(%s) as foo"%(table_or_query,)
         else:
             table_clause = table_or_query
 

--- a/cpa/icons/__init__.py
+++ b/cpa/icons/__init__.py
@@ -18,11 +18,11 @@ else:
 
 for f in glob.glob(os.path.join(search_path, "*.png")):
     globals()[os.path.basename(f)[:-4]] = wx.Image(f)
-    global cpa_32, cpa_128  # hopefully we have created these two variables
 
 
 def get_cpa_icon(size=None):
     '''The CellProfiler Analyst icon as a wx.Icon'''
+    global cpa_32, cpa_128  # hopefully these two variables were created above
     icon = wx.EmptyIcon()
     if size == None and sys.platform.startswith('win'):
         icon.CopyFromBitmap(wx.BitmapFromImage(cpa_32))

--- a/cpa/icons/__init__.py
+++ b/cpa/icons/__init__.py
@@ -18,6 +18,7 @@ else:
 
 for f in glob.glob(os.path.join(search_path, "*.png")):
     globals()[os.path.basename(f)[:-4]] = wx.Image(f)
+    global cpa_32, cpa_128  # hopefully we have created these two variables
 
 
 def get_cpa_icon(size=None):

--- a/cpa/imagegallery.py
+++ b/cpa/imagegallery.py
@@ -31,10 +31,10 @@ import re
 import cpa.helpmenu
 from imageviewer import ImageViewer
 
-
 import fastgentleboostingmulticlass
 from fastgentleboosting import FastGentleBoosting
 
+from cpa.profiling.classifier import Classifier
 #from supportvectormachines import SupportVectorMachines
 from generalclassifier import GeneralClassifier
 

--- a/cpa/normalize.py
+++ b/cpa/normalize.py
@@ -1,4 +1,4 @@
-from scipy.ndimage import median_filter
+from scipy.ndimage import median_filter, uniform_filter
 import numpy as np
 import logging
 
@@ -81,7 +81,7 @@ def square_filter_normalization(data, aggregate_type, win_size):
         raise ValueError('Programming Error: Unknown window type supplied.')
     
     try:
-        res = data / normalization_value
+        res = data / normalization_values
     except:
         logging.error("Division by zero, replace value with 0")
         res = 0
@@ -99,7 +99,7 @@ def linear_filter_normalization(data, aggregate_type, win_size):
         raise ValueError('Programming Error: Unknown window type supplied.')
     
     try:
-        res = data / normalization_value
+        res = data / normalization_values
     except:
         logging.error("Division by zero, replace value with 0")
         res = 0

--- a/cpa/plateviewer.py
+++ b/cpa/plateviewer.py
@@ -800,7 +800,7 @@ if __name__ == "__main__":
     #
     try:
         import javavbridge
-        javabridge.kill_vm()
+        javabridge.kill_vm()  # noqa: F821
     except:
         import traceback
         traceback.print_exc()

--- a/cpa/profiling/parallel.py
+++ b/cpa/profiling/parallel.py
@@ -44,7 +44,6 @@ class ParallelProcessor(object):
             from IPython.parallel import Client, LoadBalancedView
             client = Client(profile=ipython_profile)
             return IPython(client)
-            return view.imap
         elif ipython_profile == False:
             return Uniprocessing()
         else:

--- a/cpa/profiling/parallel.py
+++ b/cpa/profiling/parallel.py
@@ -1,6 +1,7 @@
 import logging
 import itertools
 from optparse import OptionGroup
+from cpa.profiling.lsf import LSF
 
 logger = logging.getLogger(__name__)
 

--- a/cpa/profiling/plot_distances.py
+++ b/cpa/profiling/plot_distances.py
@@ -11,6 +11,7 @@ from scipy.spatial.distance import cdist
 import matplotlib.pyplot as plt
 import pylab
 import cpa
+import sys
 from .profiles import Profiles
 
 def plot_distances(profiles, output_group_name=None):

--- a/cpa/profiling/plot_profiles.py
+++ b/cpa/profiling/plot_profiles.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 import pylab
 import cpa
+import sys
 from .profiles import Profiles
 
 def plot_profiles(profiles, output_group_name=None):

--- a/cpa/profiling/profile_svmnormalvector.py
+++ b/cpa/profiling/profile_svmnormalvector.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import functools
 import io
 import sys
 import os

--- a/cpa/properties.py
+++ b/cpa/properties.py
@@ -652,7 +652,7 @@ class Properties(Singleton):
                 assert self.plate_shape == supported_plate_types[self.__dict__['plate_type']], "Your properties file has incompatible values for plate_type and plate_shape."
             if self.__dict__['plate_type'] not in supported_plate_types.keys():
                 raise Exception('PROPERTIES ERROR: invalid value (%s) for plate_type. Supported plate type are: %s.'
-                                %(self.__dict__['plate_type'], ', '.join(supported_values)))
+                                %(self.__dict__['plate_type'], ', '.join(supported_plate_types)))
             self.plate_shape = supported_plate_types[self.__dict__['plate_type']]
 
         if self.field_defined('check_tables') and self.check_tables.lower() in ['true', 'yes', 'on', 't', 'y']:

--- a/cpa/scatter.py
+++ b/cpa/scatter.py
@@ -728,7 +728,7 @@ class ScatterPanel(FigureCanvasWxAgg):
     def get_key_lists(self):
         return self.key_lists
                                 
-    def set_colors(self):
+    def set_colors(self, colors):
         assert len(self.point_lists)==len(colors), 'points and colors must be of equal length'
         self.colors = colors
 

--- a/cpa/setup_py2exe.py
+++ b/cpa/setup_py2exe.py
@@ -1,6 +1,7 @@
 import distutils
 import sys
 from distutils.core import setup, Extension
+from distutils.errors import DistutilsFileError
 import py2exe
 import matplotlib
 import os
@@ -49,7 +50,9 @@ OutputBaseFilename=CellProfilerAnalyst_win32_%d
         except WindowsError:
             if key:
                 key.Close()
-            raise DistutilsFileError, "Inno Setup does not seem to be installed properly. Specifically, there is no entry in the HKEY_CLASSES_ROOT for InnoSetupScriptFile\\shell\\Compile\\command"
+            raise DistutilsFileError("Inno Setup does not seem to be installed properly. "
+				     "Specifically, there is no entry in the HKEY_CLASSES_ROOT "
+				     "for InnoSetupScriptFile\\shell\\Compile\\command")
 
 if os.path.exists('build'):
     raise Exception("Please delete the build directory before running setup.")

--- a/cpa/tableviewer.py
+++ b/cpa/tableviewer.py
@@ -201,7 +201,7 @@ class PlainTable(TableData):
         eg: to relate a unique (Table, Well, Replicate) to a unique image key.
         '''
         for i in indices: 
-            assert 0 < i < len(sortcols), 'Key column index (%s) was outside the realm of possible indices (0-%d).'%(i, len(self.sortcols)-1)
+            assert 0 < i < len(self.sortcols), 'Key column index (%s) was outside the realm of possible indices (0-%d).'%(i, len(self.sortcols)-1)
         self.key_indices = indices
         
     def get_image_keys_at_row(self, row):

--- a/cpa/tifffile.py
+++ b/cpa/tifffile.py
@@ -915,6 +915,7 @@ def lzwdecode(encoded):
 
     bitw, shr, mask = switchbitch[255]
     bitcount = 0
+    oldcode = None
     result = []
     while 1:
         code = next_code() # ~5% faster when inlining this function

--- a/setup_py2exe.py
+++ b/setup_py2exe.py
@@ -19,6 +19,7 @@ import subprocess
 import _winreg
 import javabridge
 import bioformats
+from distutils.errors import DistutilsFileError
 from shutil import rmtree
 
 
@@ -89,9 +90,9 @@ OutputBaseFilename=CellProfilerAnalyst_win32_%d
         except WindowsError:
             if key:
                 key.Close()
-            raise distutils.errors.DistutilsFileError("Inno Setup does not seem to be installed properly. "
-                                                      "Specifically, there is no entry in the HKEY_CLASSES_ROOT "
-                                                      "for InnoSetupScriptFile\\shell\\Compile\\command")
+            raise DistutilsFileError("Inno Setup does not seem to be installed properly. "
+                                     "Specifically, there is no entry in the HKEY_CLASSES_ROOT "
+                                     "for InnoSetupScriptFile\\shell\\Compile\\command")
 
 # if os.path.exists('build'):
 #    raise Exception("Please delete the build directory before running setup.")

--- a/setup_py2exe.py
+++ b/setup_py2exe.py
@@ -89,7 +89,9 @@ OutputBaseFilename=CellProfilerAnalyst_win32_%d
         except WindowsError:
             if key:
                 key.Close()
-            raise DistutilsFileError, "Inno Setup does not seem to be installed properly. Specifically, there is no entry in the HKEY_CLASSES_ROOT for InnoSetupScriptFile\\shell\\Compile\\command"
+            raise distutils.errors.DistutilsFileError("Inno Setup does not seem to be installed properly. "
+                                                      "Specifically, there is no entry in the HKEY_CLASSES_ROOT "
+                                                      "for InnoSetupScriptFile\\shell\\Compile\\command")
 
 # if os.path.exists('build'):
 #    raise Exception("Please delete the build directory before running setup.")


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree