### PR TITLE
Fix Big Sur compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: create-release
 on:
   push:
-    branches: [ beegsir ]
-#    tags:
-#      - "*"
+#    branches: [ master ]
+    tags:
+      - "*"
 
 jobs:
   build:
@@ -80,42 +80,42 @@ jobs:
       matrix:
         os: [macos-10.15, windows-2019]
         python-version: [ "3.8" ]
-#  upload:
-#    name: upload
-#    needs: build
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        id: create_release
-#        uses: actions/create-release@v1
-#        with:
-#          draft: true
-#          prerelease: true
-#          release_name: ${{ github.ref }}
-#          tag_name: ${{ github.ref }}
-#      - uses: actions/download-artifact@v1
-#        with:
-#          name: CellProfiler-Analyst-macOS-3.0.1.zip
-#          path: ./
-#      - uses: actions/download-artifact@v1
-#        with:
-#          name: CellProfiler-Analyst-Windows-3.0.1.exe
-#          path: ./
-#      - env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        uses: actions/upload-release-asset@v1
-#        with:
-#          asset_content_type: application/zip
-#          asset_name: CellProfiler-Analyst-macOS-3.0.1.zip
-#          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-macOS-3.0.1.zip
-#          upload_url: ${{ steps.create_release.outputs.upload_url }}
-#      - env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        uses: actions/upload-release-asset@v1
-#        with:
-#          asset_content_type: application/exe
-#          asset_name: CellProfiler-Analyst-Windows-3.0.1.exe
-#          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-Windows-3.0.1.exe
-#          upload_url: ${{ steps.create_release.outputs.upload_url }}
+  upload:
+    name: upload
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          draft: true
+          prerelease: true
+          release_name: ${{ github.ref }}
+          tag_name: ${{ github.ref }}
+      - uses: actions/download-artifact@v1
+        with:
+          name: CellProfiler-Analyst-macOS-3.0.1.zip
+          path: ./
+      - uses: actions/download-artifact@v1
+        with:
+          name: CellProfiler-Analyst-Windows-3.0.1.exe
+          path: ./
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1
+        with:
+          asset_content_type: application/zip
+          asset_name: CellProfiler-Analyst-macOS-3.0.1.zip
+          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-macOS-3.0.1.zip
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1
+        with:
+          asset_content_type: application/exe
+          asset_name: CellProfiler-Analyst-Windows-3.0.1.exe
+          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-Windows-3.0.1.exe
+          upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: create-release
 on:
   push:
-    branches: [ master ]
+    branches: [ beegsir ]
 #    tags:
 #      - "*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: create-release
 on:
   push:
-#    branches: [ master ]
-    tags:
-      - "*"
+    branches: [ master ]
+#    tags:
+#      - "*"
 
 jobs:
   build:
@@ -80,42 +80,42 @@ jobs:
       matrix:
         os: [macos-10.15, windows-2019]
         python-version: [ "3.8" ]
-  upload:
-    name: upload
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: create_release
-        uses: actions/create-release@v1
-        with:
-          draft: true
-          prerelease: true
-          release_name: ${{ github.ref }}
-          tag_name: ${{ github.ref }}
-      - uses: actions/download-artifact@v1
-        with:
-          name: CellProfiler-Analyst-macOS-3.0.1.zip
-          path: ./
-      - uses: actions/download-artifact@v1
-        with:
-          name: CellProfiler-Analyst-Windows-3.0.1.exe
-          path: ./
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1
-        with:
-          asset_content_type: application/zip
-          asset_name: CellProfiler-Analyst-macOS-3.0.1.zip
-          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-macOS-3.0.1.zip
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1
-        with:
-          asset_content_type: application/exe
-          asset_name: CellProfiler-Analyst-Windows-3.0.1.exe
-          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-Windows-3.0.1.exe
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+#  upload:
+#    name: upload
+#    needs: build
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        id: create_release
+#        uses: actions/create-release@v1
+#        with:
+#          draft: true
+#          prerelease: true
+#          release_name: ${{ github.ref }}
+#          tag_name: ${{ github.ref }}
+#      - uses: actions/download-artifact@v1
+#        with:
+#          name: CellProfiler-Analyst-macOS-3.0.1.zip
+#          path: ./
+#      - uses: actions/download-artifact@v1
+#        with:
+#          name: CellProfiler-Analyst-Windows-3.0.1.exe
+#          path: ./
+#      - env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        uses: actions/upload-release-asset@v1
+#        with:
+#          asset_content_type: application/zip
+#          asset_name: CellProfiler-Analyst-macOS-3.0.1.zip
+#          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-macOS-3.0.1.zip
+#          upload_url: ${{ steps.create_release.outputs.upload_url }}
+#      - env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        uses: actions/upload-release-asset@v1
+#        with:
+#          asset_content_type: application/exe
+#          asset_name: CellProfiler-Analyst-Windows-3.0.1.exe
+#          asset_path: /home/runner/work/CellProfiler-Analyst/CellProfiler-Analyst/CellProfiler-Analyst-Windows-3.0.1.exe
+#          upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -95,7 +95,9 @@ class MainGUI(wx.Frame):
         self.tbicon = None
         self.SetName('CPA')
         self.Center(wx.HORIZONTAL)
-        self.status_bar = self.CreateStatusBar()
+        # self.status_bar = self.CreateStatusBar()
+        self.status_bar = wx.StatusBar(self)
+        self.SetStatusBar(self.status_bar)
         self.log_io = True
 
         #

--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -12,6 +12,7 @@ import os.path
 import logging
 
 from cpa.dimensionreduction import DimensionReduction
+from cpa.guiutils import create_status_bar
 from cpa.util.version import display_version
 from cpa.properties import Properties
 from cpa.dbconnect import DBConnect
@@ -94,9 +95,7 @@ class MainGUI(wx.Frame):
         self.tbicon = None
         self.SetName('CPA')
         self.Center(wx.HORIZONTAL)
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        self.statusbar = wx.StatusBar(self)
-        # self.status_bar = create_status_bar(self)
+        self.status_bar = create_status_bar(self)
         self.log_io = True
 
         #
@@ -176,10 +175,6 @@ class MainGUI(wx.Frame):
         # Black background and white font
         self.console.SetDefaultStyle(wx.TextAttr(wx.WHITE,wx.BLACK))
         self.console.SetBackgroundColour('#000000')
-
-        sizer.Add(self.console, flag=wx.EXPAND, proportion=1)
-        sizer.Add(self.statusbar, flag=wx.EXPAND)
-        self.SetSizer(sizer)
 
         log_level = logging.INFO # INFO is the default log level
         self.logr = logging.getLogger()

--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -7,7 +7,6 @@
 
 
 import sys
-from io import StringIO
 import os
 import os.path
 import logging
@@ -95,9 +94,9 @@ class MainGUI(wx.Frame):
         self.tbicon = None
         self.SetName('CPA')
         self.Center(wx.HORIZONTAL)
-        # self.status_bar = self.CreateStatusBar()
-        self.status_bar = wx.StatusBar(self)
-        self.SetStatusBar(self.status_bar)
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        self.statusbar = wx.StatusBar(self)
+        # self.status_bar = create_status_bar(self)
         self.log_io = True
 
         #
@@ -176,7 +175,11 @@ class MainGUI(wx.Frame):
         
         # Black background and white font
         self.console.SetDefaultStyle(wx.TextAttr(wx.WHITE,wx.BLACK))
-        self.console.SetBackgroundColour('#000000')  
+        self.console.SetBackgroundColour('#000000')
+
+        sizer.Add(self.console, flag=wx.EXPAND, proportion=1)
+        sizer.Add(self.statusbar, flag=wx.EXPAND)
+        self.SetSizer(sizer)
 
         log_level = logging.INFO # INFO is the default log level
         self.logr = logging.getLogger()

--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -95,7 +95,7 @@ class MainGUI(wx.Frame):
         self.tbicon = None
         self.SetName('CPA')
         self.Center(wx.HORIZONTAL)
-        self.CreateStatusBar()
+        self.status_bar = self.CreateStatusBar()
         self.log_io = True
 
         #

--- a/CellProfiler-Analyst.py
+++ b/CellProfiler-Analyst.py
@@ -314,6 +314,8 @@ class MainGUI(wx.Frame):
         p.clear()
         from cpa.datamodel import DataModel
         DataModel.forget()
+        from cpa.trainingset import CellCache
+        CellCache.forget()
         self.console.Clear()
 
         if not p.is_initialized():

--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -350,7 +350,7 @@ class Classifier(wx.Frame):
         self.Bind(wx.EVT_CHOICE, self.OnSelectFilter, self.filterChoice)
         self.Bind(wx.EVT_CHOICE, self.OnClassifierChoice, self.classifierChoice)
         self.Bind(wx.EVT_BUTTON, self.OnFetch, self.fetchBtn)
-        # self.Bind(wx.EVT_BUTTON, self.OnAddSortClass, self.addSortClassBtn)
+        self.Bind(wx.EVT_BUTTON, self.OnAddSortClass, self.addSortClassBtn)
         self.Bind(wx.EVT_BUTTON, self.OnEvaluation, self.evaluationBtn)
         self.Bind(wx.EVT_BUTTON, self.OnTrainClassifier, self.trainClassifierBtn)
         self.Bind(wx.EVT_BUTTON, self.ScoreAll, self.scoreAllBtn)
@@ -476,7 +476,7 @@ class Classifier(wx.Frame):
             p.object_name[0])))
         self.scoreImageBtn.SetToolTip(
             wx.ToolTip('Highlight %s of a particular phenotype in an image.' % (p.object_name[1])))
-        # self.addSortClassBtn.SetToolTip(wx.ToolTip('Add another bin to sort your %s into.' % (p.object_name[1])))
+        self.addSortClassBtn.SetToolTip(wx.ToolTip('Add another bin to sort your %s into.' % (p.object_name[1])))
         self.unclassifiedBin.SetToolTip(
             wx.ToolTip('%s in this bin should be sorted into the bins below.' % (p.object_name[1].capitalize())))
 

--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -1,6 +1,9 @@
 # Encoding: utf-8
 
 import matplotlib
+
+from cpa.guiutils import create_status_bar
+
 matplotlib.use('WXAgg')
 
 import matplotlib.pyplot as plt
@@ -131,11 +134,11 @@ class Classifier(wx.Frame):
         self.SetMenuBar(self.menuBar)
         self.CreateMenus()
 
-        self.status_bar = self.CreateStatusBar()
-
+        self.status_bar = create_status_bar(self, force=True)
         #### Create GUI elements
         # Top level - three split windows
         self.splitter = wx.SplitterWindow(self, style=wx.NO_BORDER | wx.SP_3DSASH | wx.SP_LIVE_UPDATE)
+
         self.fetch_and_rules_panel = wx.Panel(self.splitter)
         self.bins_splitter = wx.SplitterWindow(self.splitter, style=wx.NO_BORDER | wx.SP_3DSASH | wx.SP_LIVE_UPDATE)
 
@@ -347,7 +350,7 @@ class Classifier(wx.Frame):
         self.Bind(wx.EVT_CHOICE, self.OnSelectFilter, self.filterChoice)
         self.Bind(wx.EVT_CHOICE, self.OnClassifierChoice, self.classifierChoice)
         self.Bind(wx.EVT_BUTTON, self.OnFetch, self.fetchBtn)
-        self.Bind(wx.EVT_BUTTON, self.OnAddSortClass, self.addSortClassBtn)
+        # self.Bind(wx.EVT_BUTTON, self.OnAddSortClass, self.addSortClassBtn)
         self.Bind(wx.EVT_BUTTON, self.OnEvaluation, self.evaluationBtn)
         self.Bind(wx.EVT_BUTTON, self.OnTrainClassifier, self.trainClassifierBtn)
         self.Bind(wx.EVT_BUTTON, self.ScoreAll, self.scoreAllBtn)
@@ -473,7 +476,7 @@ class Classifier(wx.Frame):
             p.object_name[0])))
         self.scoreImageBtn.SetToolTip(
             wx.ToolTip('Highlight %s of a particular phenotype in an image.' % (p.object_name[1])))
-        self.addSortClassBtn.SetToolTip(wx.ToolTip('Add another bin to sort your %s into.' % (p.object_name[1])))
+        # self.addSortClassBtn.SetToolTip(wx.ToolTip('Add another bin to sort your %s into.' % (p.object_name[1])))
         self.unclassifiedBin.SetToolTip(
             wx.ToolTip('%s in this bin should be sorted into the bins below.' % (p.object_name[1].capitalize())))
 

--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -131,7 +131,7 @@ class Classifier(wx.Frame):
         self.SetMenuBar(self.menuBar)
         self.CreateMenus()
 
-        self.CreateStatusBar()
+        self.status_bar = self.CreateStatusBar()
 
         #### Create GUI elements
         # Top level - three split windows
@@ -187,7 +187,7 @@ class Classifier(wx.Frame):
         self.scoreImageBtn = wx.Button(self.find_rules_panel, -1, 'Score Image')
 
         # add sorting class
-        self.addSortClassBtn = wx.Button(self.GetStatusBar(), -1, "Add new class", style=wx.BU_EXACTFIT)
+        self.addSortClassBtn = wx.Button(self.status_bar, -1, "Add new class", style=wx.BU_EXACTFIT)
 
         #### Create Sizers
         self.fetchSizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -358,7 +358,7 @@ class Classifier(wx.Frame):
         self.nNeuronsTxt.Bind(wx.EVT_TEXT, self.ValidateNumberOfNeurons)
         self.nObjectsTxt.Bind(wx.EVT_TEXT_ENTER, self.OnFetch)
 
-        self.GetStatusBar().Bind(wx.EVT_SIZE, self.status_bar_onsize)
+        self.status_bar.Bind(wx.EVT_SIZE, self.status_bar_onsize)
         wx.CallAfter(self.status_bar_onsize, None)
 
         self.Bind(wx.EVT_MENU, self.OnClose, self.exitMenuItem)
@@ -391,7 +391,7 @@ class Classifier(wx.Frame):
     def status_bar_onsize(self, event):
         # draw the "add sort class..." button in the status bar
         button = self.addSortClassBtn
-        width, height = self.GetStatusBar().GetClientSize()
+        width, height = self.status_bar.GetClientSize()
         # diagonal lines drawn on mac, so move let by height.
         button.SetPosition((width - button.GetSize()[0] - 1 - height, button.GetPosition()[1]))
 

--- a/cpa/datatable.py
+++ b/cpa/datatable.py
@@ -381,7 +381,7 @@ class DataGrid(wx.Frame):
         self.GetMenuBar().Append(self.dbmenu, 'Database')
         if self.grid:
             self.CreateColumnMenu()
-        self.CreateStatusBar()
+        self.status_bar = self.CreateStatusBar()
 
         self.SetSize((800,500))
         if self.grid:

--- a/cpa/datatable.py
+++ b/cpa/datatable.py
@@ -2,6 +2,7 @@
 
 from cpa import dbconnect
 from cpa.dbconnect import DBConnect
+from cpa.guiutils import create_status_bar
 from .datamodel import DataModel
 from .properties import Properties
 from tempfile import gettempdir
@@ -381,7 +382,7 @@ class DataGrid(wx.Frame):
         self.GetMenuBar().Append(self.dbmenu, 'Database')
         if self.grid:
             self.CreateColumnMenu()
-        self.status_bar = self.CreateStatusBar()
+        self.status_bar = create_status_bar(self)
 
         self.SetSize((800,500))
         if self.grid:

--- a/cpa/generalclassifier.py
+++ b/cpa/generalclassifier.py
@@ -20,35 +20,34 @@ import sys
 # MatPlotLib currently has a bug on Windows which crashes wx if you close an interactive plot window.
 # This should be fixed in MPL 3.4, but for now we'll monkey patch in the fix.
 # See MPL PR #19596 for more details. - dstirling Mar 2021
-if sys.platform == 'win32':
-    import wx
-    import matplotlib.backends.backend_wx
-    from matplotlib._pylab_helpers import Gcf
+import wx
+import matplotlib.backends.backend_wx
+from matplotlib._pylab_helpers import Gcf
 
-    def mp_onClose(self, event):
-        self.canvas.close_event()
-        self.canvas.stop_event_loop()
-        self.figmgr.frame = None
-        Gcf.destroy(self.figmgr)
-        event.Skip()
+def mp_onClose(self, event):
+    self.canvas.close_event()
+    self.canvas.stop_event_loop()
+    self.figmgr.frame = None
+    Gcf.destroy(self.figmgr)
+    event.Skip()
 
-    def mp_Destroy(self, *args, **kwargs):
-        try:
-            self.canvas.mpl_disconnect(self.toolbar._id_drag)
-        except AttributeError:
-            pass
-        if self and not self.IsBeingDeleted():
-            wx.Frame.Destroy(self, *args, **kwargs)
-        return True
+def mp_Destroy(self, *args, **kwargs):
+    try:
+        self.canvas.mpl_disconnect(self.toolbar._id_drag)
+    except AttributeError:
+        pass
+    if self and not self.IsBeingDeleted():
+        wx.Frame.Destroy(self, *args, **kwargs)
+    return True
 
-    def mp_mandestroy(self, *args):
-        frame = self.frame
-        if frame:
-            wx.CallAfter(frame.Close)
+def mp_mandestroy(self, *args):
+    frame = self.frame
+    if frame:
+        wx.CallAfter(frame.Close)
 
-    matplotlib.backends.backend_wx.FigureFrameWx._onClose = mp_onClose
-    matplotlib.backends.backend_wx.FigureFrameWx.Destroy = mp_Destroy
-    matplotlib.backends.backend_wx.FigureManagerWx.destroy = mp_mandestroy
+matplotlib.backends.backend_wx.FigureFrameWx._onClose = mp_onClose
+matplotlib.backends.backend_wx.FigureFrameWx.Destroy = mp_Destroy
+matplotlib.backends.backend_wx.FigureManagerWx.destroy = mp_mandestroy
 ##########
 
 class GeneralClassifier(BaseEstimator, ClassifierMixin):

--- a/cpa/guiutils.py
+++ b/cpa/guiutils.py
@@ -840,7 +840,7 @@ def show_load_dialog():
 
 def create_status_bar(parent, force=False):
     import platform
-    if not (platform.system() == "Darwin" and platform.mac_ver()[0].startswith('11')):
+    if (platform.system() == "Darwin" and platform.mac_ver()[0].startswith('11')):
         # wx 4.1.0 crashes on Big Sur if you try to make a status bar
         if force:
             tb = wx.ToolBar(parent, style=wx.TB_BOTTOM)

--- a/cpa/guiutils.py
+++ b/cpa/guiutils.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import wx
 import wx.adv
 import os
@@ -839,9 +840,13 @@ def show_load_dialog():
         return False
 
 def create_status_bar(parent, force=False):
-    import platform
-    if (platform.system() == "Darwin" and platform.mac_ver()[0].startswith('11')):
-        # wx 4.1.0 crashes on Big Sur if you try to make a status bar
+    if platform.system() == "Darwin" and platform.mac_ver()[0].startswith('11'):
+        # wx 4.1.0 crashes on Big Sur if you try to make a status bar.
+        # Redirect messages to the log instead.
+        # Provide a toolbar if we need to place buttons in the status bar.
+        def log_status(text):
+            logging.info(text)
+        parent.SetStatusText = log_status
         if force:
             tb = wx.ToolBar(parent, style=wx.TB_BOTTOM)
             parent.SetToolBar(tb)

--- a/cpa/guiutils.py
+++ b/cpa/guiutils.py
@@ -837,3 +837,16 @@ def show_load_dialog():
     else:
         wx.CallAfter(dlg.Destroy)
         return False
+
+def create_status_bar(parent, force=False):
+    import platform
+    if not (platform.system() == "Darwin" and platform.mac_ver()[0].startswith('11')):
+        # wx 4.1.0 crashes on Big Sur if you try to make a status bar
+        if force:
+            tb = wx.ToolBar(parent, style=wx.TB_BOTTOM)
+            parent.SetToolBar(tb)
+            return tb
+        else:
+            return None
+    else:
+        return parent.CreateStatusBar()

--- a/cpa/imagegallery.py
+++ b/cpa/imagegallery.py
@@ -77,7 +77,7 @@ class ImageGallery(wx.Frame):
         self.SetMenuBar(self.menuBar)
         self.CreateMenus()
 
-        self.CreateStatusBar()
+        self.status_bar = self.CreateStatusBar()
 
         #### Create GUI elements
         # Top level - three split windows

--- a/cpa/imagegallery.py
+++ b/cpa/imagegallery.py
@@ -3,6 +3,9 @@
 
 
 import matplotlib
+
+from cpa.guiutils import create_status_bar
+
 matplotlib.use('WXAgg')
 
 import sys
@@ -77,7 +80,7 @@ class ImageGallery(wx.Frame):
         self.SetMenuBar(self.menuBar)
         self.CreateMenus()
 
-        self.status_bar = self.CreateStatusBar()
+        self.status_bar = create_status_bar(self)
 
         #### Create GUI elements
         # Top level - three split windows

--- a/cpa/tableviewer.py
+++ b/cpa/tableviewer.py
@@ -564,7 +564,7 @@ class TableViewer(wx.Frame):
 
         self.GetMenuBar().Append(cpa.helpmenu.make_help_menu(self, manual_url="6_table_viewer.html"), 'Help')
         
-        self.CreateStatusBar()
+        self.status_bar = self.CreateStatusBar()
         
         self.Bind(wx.EVT_MENU, self.on_new_table, new_table_item)
         self.Bind(wx.EVT_MENU, self.on_load_csv, load_csv_menu_item)

--- a/cpa/tableviewer.py
+++ b/cpa/tableviewer.py
@@ -17,6 +17,7 @@ import numpy as np
 import wx
 import wx.grid as  gridlib
 import cpa.helpmenu
+from cpa.guiutils import create_status_bar
 from .properties import Properties
 from . import dbconnect
 from .datamodel import DataModel
@@ -564,7 +565,7 @@ class TableViewer(wx.Frame):
 
         self.GetMenuBar().Append(cpa.helpmenu.make_help_menu(self, manual_url="6_table_viewer.html"), 'Help')
         
-        self.status_bar = self.CreateStatusBar()
+        self.status_bar = create_status_bar(self)
         
         self.Bind(wx.EVT_MENU, self.on_new_table, new_table_item)
         self.Bind(wx.EVT_MENU, self.on_load_csv, load_csv_menu_item)


### PR DESCRIPTION
For some reason MacOS 11 really doesn't like having a status bar in a window without a master sizer, instead it'll create a segfault if you're on wxpython 4.1.0 or do other weird things if you're on 4.1.1.

My solution for now is to avoid creating status bars on that particular OS. I've set it up to redirect status log entries to the main console and replace the status bar with a toolbar instance in modules where we need to put other widgets into the status bar.

It also turns out that the crashing when working with multiple Evaluation report windows was related to the same issue we saw on Windows when closing them. Applying the same patch to MacOS seems to fix that.

This hopefully gets us towards resolving #297 and fixes #296