### PR TITLE
Make check_tables work with complex databases

### DIFF
--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -1658,20 +1658,30 @@ class DBConnect(metaclass=Singleton):
             else:
                 query = f"""CREATE OR REPLACE VIEW {p.object_table} AS SELECT * FROM {object_table} WHERE {
                 " IS NOT NULL AND ".join(all_cols)} IS NOT NULL AND {" != '' AND ".join(all_cols)}  != ''"""
-        elif DB_TYPE == 'sqlite':
-            query = "PRAGMA table_info(%s)"%object_table
             self.execute(query)
-            query = 'DROP TABLE IF EXISTS %s'%(p.object_table)
+        elif DB_TYPE == 'sqlite':
+            # SQL can only handle 1000 comparisons in a query. If we have too many columns we'll need to break it up.
+            col_buffer = [all_cols[i:i + 400] for i in range(0, len(all_cols), 400)]
+            # Do the largest chunk first, it'll reduce work later on.
+            to_test = col_buffer.pop(0)
+
+            query = f"PRAGMA table_info({object_table})"
+            self.execute(query)
+            query = f'DROP TABLE IF EXISTS {p.object_table}'
             self.execute(query)
             if len(AreaShape_Area) > 0:
                 query = f"""CREATE TABLE {p.object_table} AS SELECT * FROM {object_table} WHERE {
-                " IS NOT NULL AND ".join(all_cols)} IS NOT NULL AND {" != '' AND ".join(all_cols)}  != '' AND {
+                " IS NOT NULL AND ".join(to_test)} IS NOT NULL AND {" != '' AND ".join(to_test)}  != '' AND {
                 " > 0 AND ".join(AreaShape_Area)} > 0"""
             else:
                 query = f"""CREATE TABLE {p.object_table} AS SELECT * FROM {object_table} WHERE {
-                " IS NOT NULL AND ".join(all_cols)} IS NOT NULL AND {" != '' AND ".join(all_cols)}  != ''"""
-        self.execute(query)
-
+                " IS NOT NULL AND ".join(to_test)} IS NOT NULL AND {" != '' AND ".join(to_test)}  != ''"""
+            self.execute(query)
+            for chunk in col_buffer:
+                query = f"""DELETE FROM {p.object_table} WHERE {
+                " IS NOT NULL AND ".join(chunk)} IS NOT NULL AND {" != '' AND ".join(chunk)}  != ''"""
+                self.execute(query)
+        self.Commit()
         # Inform user of what we did. Also check whether we nuked the table.
         try:
             query = f"SELECT COUNT() FROM {p.object_table}"

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -1197,8 +1197,8 @@ class DBConnect(metaclass=Singleton):
             col_names = self.GetColumnNames(p.object_table)
             col_types = self.GetColumnTypes(p.object_table)
             # automatically ignore all string-type columns
-            #print col_names, col_types
-            self.classifierColNames = [col for col, type in zip(col_names, col_types) if type not in [str, None]]
+            # ColumnTypes will return None for unknown formats, rather than a proper type.
+            self.classifierColNames = [col for col, coltype in zip(col_names, col_types) if coltype not in (str, None)]
             # automatically ignore ID columns
             if p.table_id in self.classifierColNames:
                 self.classifierColNames.remove(p.table_id)

--- a/cpa/dimensionreduction.py
+++ b/cpa/dimensionreduction.py
@@ -784,7 +784,7 @@ class ReduxControlPanel(wx.Panel):
                 return
 
         # Define a progress dialog
-        dlg = wx.ProgressDialog('Generating figure...', 'Generating ...', 100, parent=self,
+        dlg = wx.ProgressDialog('Generating figure...', 'Fetching data ...', 100, parent=self,
                                 style=wx.PD_APP_MODAL | wx.PD_CAN_ABORT)
         # Reset selections
         self.figpanel.patches = []


### PR DESCRIPTION
We had a problem where check_tables functionality failed on SQLite files which had more than 500 measurement columns. SQLite appears to have a limit of 1000 comparators per operation, and since we check everything against both NULL and empty strings you could easily exceed that limit.

To resolve this for now, I've made it so that table checking breaks up the SQL commands into chunks of 400 columns. We first make the checked table using an initial set of rules, then go through and delete columns which fail additional batches.

The main downside to this approach is that deleting rows seems to lock the database, so we'll have to write the checked tables properly instead of keeping them as temporary tables.