### PR TITLE
Fix crash when no objects are found within a score-all chunk

### DIFF
--- a/cpa/multiclasssql.py
+++ b/cpa/multiclasssql.py
@@ -255,7 +255,7 @@ def PerImageCounts(classifier, num_classes, filter_name=None, cb=None):
     # For each image clause, classify the cells using the model
     # then for each image key, count the number in each class (and maybe area)
     def do_by_steps(tables, filter_name, area_score=False):
-        filter_clause = '1 = 1'
+        filter_clause = None
         join_clause = ''
         if filter_name is not None:
             filter = p._filters[filter_name]
@@ -295,7 +295,9 @@ def PerImageCounts(classifier, num_classes, filter_name=None, cb=None):
                                 ",".join(db.GetColnamesForClassifier()), tables,
                                 join_clause, where_clause),
                               silent=(idx > 10))
-
+            if not data:
+                logging.info(f"No objects found for condition {where_clause}")
+                continue
             cell_data, image_keys = processData(data)
             predicted_classes = classifier.Predict(cell_data)
             for i in range(0, len(predicted_classes)):


### PR DESCRIPTION
As described on the [forum](https://forum.image.sc/t/cpa-score-all-indexerror-tuple-index-out-of-range/57856), some users reported that the Score All function crashed with some databases.

Score All runs by breaking the objects list up into reasonably sized segments based on the image number. This crash happened when a particular segment (e.g. ImageNumbers 50-60) contained no objects. The fix should be simply continuing if there's no data to work with.

I've also removed the redundant 'AND 1=1' condition which was being added to queries whenever there was no filter active, because I see no reason to be doing this.