### PR TITLE
Issues/310 (visualization of 3D datasets in CPA)

### DIFF
--- a/.image-config.json
+++ b/.image-config.json
@@ -1,0 +1,15 @@
+{
+  "storePath": "/images",
+  "wwwRoot": "/",
+  "grammars": {
+    "Markdown": {
+      "url": "![](${url})"
+    },
+    "GitHub Markdown": {
+      "url": "![](${url})"
+    },
+    "HTML": {
+      "url": "<img src=\"${url}\" alt=\"\">"
+    }
+  }
+}

--- a/Properties_README.txt
+++ b/Properties_README.txt
@@ -107,6 +107,7 @@ well_id     =  <your_well_id_column>
 
 cell_x_loc  =  <your_object_x_location_column>
 cell_y_loc  =  <your_object_y_location_column>
+cell_z_loc  =  <your_object_z_location_column>
 
 
 # ======== Image Path and Filename Columns ========
@@ -336,4 +337,13 @@ force_bioformats = no
 # fetching and randomisation.
 
 use_legacy_fetcher = no
+
+# ======== Process as 3D (visualize a different z position per object) ========
+# OPTIONAL
+# [yes/no]  In 3D datasets, this optionally displays in CPA classifier a separate
+# z slice for each object depending on that object's center position in z. Useful
+# for classifying cells from 3D data.
+
+process_3D = no
+
 

--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -113,8 +113,8 @@ class Classifier(wx.Frame):
         #         self.image_tile_size = min([image_width, image_height])
         #     self.scale = 100.0/float(self.image_tile_size)
 
-        self.required_fields = ['object_table', 'object_id', 'cell_x_loc', 'cell_y_loc']        
-        
+        self.required_fields = ['object_table', 'object_id', 'cell_x_loc', 'cell_y_loc']
+
         for field in self.required_fields:
             if not p.field_defined(field):
                 errdlg = wx.MessageDialog(self, 'Properties field "%s" is required for Classifier.'% (field),
@@ -123,7 +123,7 @@ class Classifier(wx.Frame):
                 errdlg.Destroy()
                 logging.error('Properties field "%s" is required for Classifier.'% (field))
                 self.Destroy()
-                return 
+                return
 
         self.contrast = 'Linear'
         self.defaultTSFileName = None
@@ -259,7 +259,7 @@ class Classifier(wx.Frame):
         self.fetch_and_rules_sizer.Add((5, 5))
         self.fetch_and_rules_sizer.Add(self.find_rules_panel, flag=wx.EXPAND)
         self.fetch_and_rules_sizer.Add((5, 5))
-        self.fetch_and_rules_sizer.Add(self.rules_text, proportion=1, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5)      
+        self.fetch_and_rules_sizer.Add(self.rules_text, proportion=1, flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=5)
         self.fetch_and_rules_sizer.Add((5, 5))
         self.fetch_and_rules_panel.SetSizerAndFit(self.fetch_and_rules_sizer)
 
@@ -295,7 +295,7 @@ class Classifier(wx.Frame):
         RandomForestClassifier = GeneralClassifier("ensemble.RandomForestClassifier(n_estimators=100)", self)
         AdaBoostClassifier = GeneralClassifier("ensemble.AdaBoostClassifier()", self)
         SVC = GeneralClassifier("svm.SVC(probability=True)", self, scaler=True)
-        
+
         GradientBoostingClassifier = GeneralClassifier("ensemble.GradientBoostingClassifier()", self)
         LogisticRegression = GeneralClassifier("linear_model.LogisticRegression()", self)
         LDA = GeneralClassifier("discriminant_analysis.LinearDiscriminantAnalysis()", self)
@@ -380,7 +380,7 @@ class Classifier(wx.Frame):
             response = dlg.ShowModal()
             if response == wx.ID_YES:
                 name, file_extension = os.path.splitext(p.training_set)
-                if '.txt' == file_extension: 
+                if '.txt' == file_extension:
                     self.LoadTrainingSet(p.training_set)
                 elif '.csv' == file_extension:
                     self.LoadTrainingSetCSV(p.training_set)
@@ -914,7 +914,7 @@ class Classifier(wx.Frame):
         # DD: Add new option to select uncertain images
         if self.algorithm.IsTrained() and self.algorithm.name != "FastGentleBoosting":
             selectableClasses += ['uncertain']
-        
+
         self.obClassChoice.SetItems(selectableClasses)
         if len(selectableClasses) < sel:
             sel = 0
@@ -943,7 +943,7 @@ class Classifier(wx.Frame):
     # Save object thumbnails of training set
     def OnSaveThumbnails(self, evt):
 
-        saveDialog = wx.DirDialog(self, "Choose input directory", 
+        saveDialog = wx.DirDialog(self, "Choose input directory",
                                    style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT | wx.FD_CHANGE_DIR)
         if saveDialog.ShowModal() == wx.ID_OK:
             directory = saveDialog.GetPath()
@@ -1208,7 +1208,7 @@ class Classifier(wx.Frame):
     # Get the name of the loaded model file
     def GetModelData(self, filename):
         import joblib
-        try: 
+        try:
             return joblib.load(filename)
         except:
             logging.error("Couldn't check model!")
@@ -1307,7 +1307,7 @@ class Classifier(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             filename = dlg.GetPath()
             name, file_extension = os.path.splitext(filename)
-            if '.txt' == file_extension: 
+            if '.txt' == file_extension:
                 self.LoadTrainingSet(filename)
             elif '.csv' == file_extension:
                 self.LoadTrainingSetCSV(filename)
@@ -1604,7 +1604,7 @@ class Classifier(wx.Frame):
                     dlg.Pulse()
                     # Convert labels
                     self.algorithm.Train(self.trainingSet.label_array, self.trainingSet.values, output)
-                    self.nRules = nRules # Hack 
+                    self.nRules = nRules # Hack
 
                 # JK - End Modification
 
@@ -1667,12 +1667,12 @@ class Classifier(wx.Frame):
         for className, obKeys in classHits.items():
             training_keys = [key for key in obKeys if key in training_obKeys]
             if training_keys:
-                trainingCoords['training ' + className] = db.GetObjectsCoords(training_keys)
+                trainingCoords['training ' + className] = db.GetObjectsCoords(training_keys)[0:2]
             else:
                 trainingCoords['training ' + className] = []
             object_keys = [key for key in obKeys if key not in training_obKeys]
             if object_keys:
-                classCoords[className] = db.GetObjectsCoords(object_keys)
+                classCoords[className] = db.GetObjectsCoords(object_keys)[0:2]
             else:
                 classCoords[className] = []
         classCoords.update(trainingCoords)
@@ -2037,7 +2037,7 @@ class Classifier(wx.Frame):
                 self.filterChoice.Select(0)
             cff.Destroy()
         self.fetch_panel.Layout()
-        self.fetch_panel.Refresh() 
+        self.fetch_panel.Refresh()
 
     def UpdateFilterChoices(self, evt):
         selected_string = self.filterChoice.GetStringSelection()
@@ -2245,7 +2245,7 @@ class Classifier(wx.Frame):
             dlg.SetValue(string)
             if dlg.ShowModal() == wx.ID_OK:
                 try:
-                    s = dlg.GetValue() 
+                    s = dlg.GetValue()
                     s = s.split("\n")[:-1] # Get rid of the last element
                     for el in s:
                         el = el.split(" : ")
@@ -2292,8 +2292,8 @@ class Classifier(wx.Frame):
             result = ""
             for i,var in enumerate(variances):
                 result += colnames[indices[i]] + " , " + str(var) + "\n"
-            
-            
+
+
             dlg = wx.TextEntryDialog(self, 'Lowest Feature Variance:', 'Features ordered by lowest variance',
                                      style=wx.TE_MULTILINE | wx.OK )
             dlg.SetSize((500,500))
@@ -2387,7 +2387,7 @@ class Classifier(wx.Frame):
         clf = OneVsRestClassifier(self.algorithm.classifier)
         clf.fit(X_train, y_train)
         if hasattr(self.algorithm.classifier, "predict_proba"):
-            y_score = clf.predict_proba(X_test)        
+            y_score = clf.predict_proba(X_test)
         else: # use decision function
             y_score = clf.decision_function(X_test)
 
@@ -2453,7 +2453,7 @@ class Classifier(wx.Frame):
         clf = OneVsRestClassifier(self.algorithm.classifier)
         clf.fit(X_train, y_train)
         if hasattr(self.algorithm.classifier, "predict_proba"):
-            y_score = clf.predict_proba(X_test)        
+            y_score = clf.predict_proba(X_test)
         else: # use decision function
             y_score = clf.decision_function(X_test)
 
@@ -2503,8 +2503,8 @@ class Classifier(wx.Frame):
         if(len(df) > 7):
             sns.barplot(x="Probs", y="Class", data=df, palette="RdBu_r",ax=ax)
         else:
-            sns.barplot(y="Probs", x="Class", data=df, palette="RdBu_r",ax=ax)    
-        
+            sns.barplot(y="Probs", x="Class", data=df, palette="RdBu_r",ax=ax)
+
         plt.show()
 
     def PlotLearningCurve(self,estimator, plot_title, X, y, ylim=None, cv=None,
@@ -2539,7 +2539,7 @@ class Classifier(wx.Frame):
 
         n_jobs : integer, optional
             Number of jobs to run in parallel (default 1).
-        """    
+        """
         from sklearn.model_selection import learning_curve
 
         plt.figure()
@@ -2570,7 +2570,7 @@ class Classifier(wx.Frame):
 
         plt.legend(loc="best")
         plt.show()
-        
+
 
 class StopCalculating(Exception):
     pass

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -683,10 +683,14 @@ class DBConnect(metaclass=Singleton):
                             p.cell_x_loc, p.cell_y_loc, p.cell_z_loc, p.object_table,
                             GetWhereClauseForObjects([obKey])), silent=silent)
             reslist = [list(coord) for coord in res] #tuples are immutable so first make tuple of tuples a list of lists
-            reslist[0][2]=round(reslist[0][2]) #round to get z slice
-            #reslist[0][2]=4
-            restup = [tuple(coord) for coord in reslist] #then convert back to list of tuples
-            res = tuple(restup) #convert to tuple of tuples
+            try:
+                reslist[0][2]=round(reslist[0][2]) #round to get z slice
+                print(reslist)
+                restup = [tuple(coord) for coord in reslist] #then convert back to list of tuples
+                res = tuple(restup) #convert to tuple of tuples
+            except:
+                print("Correct types for coordinates not found. Check your per-object table and ensure every object has XYZ coordinates.")
+            
         else:
             res = self.execute('SELECT %s, %s FROM %s WHERE %s'%(
                             p.cell_x_loc, p.cell_y_loc, p.object_table,

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -1,5 +1,6 @@
 
 import decimal
+from http.client import NO_CONTENT
 import random
 from .properties import Properties
 from .singleton import Singleton
@@ -677,7 +678,7 @@ class DBConnect(metaclass=Singleton):
     def GetObjectCoords(self, obKey, none_ok=False, silent=False):
         '''Returns the specified object's x, y, z coordinates in an image.
         '''
-        if p.cell_z_loc:
+        if p.process_3D:
             res = self.execute('SELECT %s, %s, %s FROM %s WHERE %s'%(
                             p.cell_x_loc, p.cell_y_loc, p.cell_z_loc, p.object_table,
                             GetWhereClauseForObjects([obKey])), silent=silent)
@@ -691,9 +692,6 @@ class DBConnect(metaclass=Singleton):
                             p.cell_x_loc, p.cell_y_loc, p.object_table,
                             GetWhereClauseForObjects([obKey])), silent=silent)
 
-            #print(len(elm))
-        # for elm in res:
-        #     print("inside get ObjCoords", elm)
         if len(res) == 0 or res[0][0] is None or res[0][1] is None:
             message = ('Failed to load coordinates for object key %s. This may '
                        'indicate a problem with your per-object table.\n'
@@ -706,9 +704,9 @@ class DBConnect(metaclass=Singleton):
             return res[0]
 
     def GetObjectsCoords(self, obKeys, none_ok=False, silent=False):
-        '''Returns the specified objects' x, y, z coordinates in an image.
+        '''Returns the specified objects' x, y, (and sometimes) z coordinates in an image.
         '''
-        if p.cell_z_loc:
+        if p.process_3D:
             res = self.execute('SELECT %s, %s, %s, %s, %s FROM %s WHERE %s'%(
                         p.image_id, p.object_id, p.cell_x_loc, p.cell_y_loc, p.cell_z_loc, p.object_table,
                         GetWhereClauseForObjects(obKeys)), silent=silent)
@@ -740,7 +738,7 @@ class DBConnect(metaclass=Singleton):
 
     def GetAllObjectCoordsFromImage(self, imKey, z=None):
         ''' Returns a list of lists x, y, z coordinates for all objects in the given image. '''
-        if z:
+        if p.process_3D and z is not None:
             select = 'SELECT '+p.cell_x_loc+', '+p.cell_y_loc+','+p.cell_z_loc+' FROM '+p.object_table+' WHERE '+GetWhereClauseForImages([imKey])+' ORDER BY '+p.object_id
         else:
             select = 'SELECT '+p.cell_x_loc+', '+p.cell_y_loc+' FROM '+p.object_table+' WHERE '+GetWhereClauseForImages([imKey])+' ORDER BY '+p.object_id

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -33,7 +33,7 @@ def DBError():
     elif p.db_type.lower() == 'sqlite':
         import sqlite3
         return sqlite3.Error
-    
+
 def DBOperationalError():
     '''returns the Error type associated with the db library in use'''
     if p.db_type.lower() == 'mysql':
@@ -71,17 +71,17 @@ def sqltype_to_pythontype(t):
     '''
     t = t.upper()
     if (t.startswith('INT') or t.startswith('DECIMAL') or t.startswith('BIGINT') or
-        t in ['TINYINT', 'SMALLINT', 'MEDIUMINT', 'UNSIGNED BIG INT', 
+        t in ['TINYINT', 'SMALLINT', 'MEDIUMINT', 'UNSIGNED BIG INT',
               'INT2', 'INT8', 'NUMERIC', 'BOOLEAN', 'DATE', 'DATETIME']):
         return int
     elif t in ['REAL', 'DOUBLE', 'DOUBLE PRECISION', 'FLOAT']:
         return float
     elif (t.startswith('CHARACTER') or t.startswith('VARCHAR') or t.startswith('CHAR') or
-          t.startswith('VARYING CHARACTER') or t.startswith('NCHAR') or 
+          t.startswith('VARYING CHARACTER') or t.startswith('NCHAR') or
           t.startswith('NCHAR') or t.startswith('NATIVE CHARACTER') or
           t.startswith('NVARCHAR') or t in ['TEXT', 'CLOB']):
         return str
-    
+
 #TODO: this doesn't belong in this module
 def get_data_table_from_csv_reader(reader):
     '''reads a csv table into a 2d list'''
@@ -104,7 +104,7 @@ def clean_up_colnames(colnames):
     colnames = [col.replace(' ','_') for col in colnames]
     colnames = [col.replace('\n','_') for col in colnames]
     colnames = [''.join([c for c in col if re.match('[A-Za-z0-9_]',c)]) for col in colnames]
-    return colnames        
+    return colnames
 
 
 def well_key_columns(table_name=''):
@@ -155,7 +155,7 @@ def object_key_defs():
 def GetWhereClauseForObjects(obkeys, table_name=None):
     '''
     Return a SQL WHERE clause that matches any of the given object keys.
-    Example: GetWhereClauseForObjects([(1, 3), (2, 4)]) => "ImageNumber=1 
+    Example: GetWhereClauseForObjects([(1, 3), (2, 4)]) => "ImageNumber=1
              AND ObjectNumber=3 OR ImageNumber=2 AND ObjectNumber=4"
     '''
     if table_name is None:
@@ -176,7 +176,7 @@ def GetWhereClauseForObjects(obkeys, table_name=None):
 def GetWhereClauseForImages(imkeys):
     '''
     Return a SQL WHERE clause that matches any of the given image keys.
-    Example: GetWhereClauseForImages([(3,), (4,)]) => 
+    Example: GetWhereClauseForImages([(3,), (4,)]) =>
              "(ImageNumber IN (3, 4))"
     '''
     imkeys.sort()
@@ -191,7 +191,7 @@ def GetWhereClauseForImages(imkeys):
             imnums = imkeys[(imkeys[:,0]==tnum), 1]
             count += len(imnums)
             if len(imnums)>0:
-                wheres += ['(%s=%s AND %s IN (%s))'%(p.table_id, tnum, 
+                wheres += ['(%s=%s AND %s IN (%s))'%(p.table_id, tnum,
                             p.image_id, ','.join([str(k) for k in imnums]))]
             tnum += 1
         return ' OR '.join(wheres)
@@ -199,7 +199,7 @@ def GetWhereClauseForImages(imkeys):
 def GetWhereClauseForWells(keys, table_name=None):
     '''
     Return a SQL WHERE clause that matches any of the given well keys.
-    Example: GetWhereClauseForImages([('plate1', 'A01'), ('plate1', 'A02')]) => 
+    Example: GetWhereClauseForImages([('plate1', 'A01'), ('plate1', 'A02')]) =>
              "(plate="plate1" AND well="A01" OR plate="plate1" AND "A02"))"
     '''
     if table_name is None:
@@ -223,14 +223,14 @@ def UniqueObjectClause(table_name=None):
 def UniqueImageClause(table_name=None):
     '''
     Returns a clause for specifying a unique image in MySQL.
-    Example: "SELECT <UniqueObjectClause()> FROM <mydb>;" would return all image keys 
+    Example: "SELECT <UniqueObjectClause()> FROM <mydb>;" would return all image keys
     '''
     return ','.join(image_key_columns(table_name))
 
 def UniqueWellClause(table_name=None):
     '''
     Returns a clause for specifying a unique image in MySQL.
-    Example: "SELECT <UniqueObjectClause()> FROM <mydb>;" would return all image keys 
+    Example: "SELECT <UniqueObjectClause()> FROM <mydb>;" would return all image keys
     '''
     return ','.join(well_key_columns(table_name))
 
@@ -243,7 +243,7 @@ def get_csv_filenames_from_sql_file():
     f.close()
     files = re.findall(r" '\w+\.[Cc][Ss][Vv]' ",lines)
     files = [f[2:-2] for f in files]
-    imcsvs = [] 
+    imcsvs = []
     obcsvs = []
     for file in files:
         if file.lower().endswith('image.csv'):
@@ -275,11 +275,11 @@ def _check_colname_user(properties, table, colname):
     if table in [properties.image_table, properties.object_table] and not colname.lower().startswith('user_'):
         raise ValueError('User-defined columns in the image and object tables must have names beginning with "User_".')
 
-    
+
 class DBConnect(metaclass=Singleton):
     '''
     DBConnect abstracts calls to MySQLdb/SQLite. It's a singleton that maintains
-    unique connections for each thread that uses it.  These connections are 
+    unique connections for each thread that uses it.  These connections are
     automatically created on "execute", and results are automatically returned
     as a list.
     '''
@@ -295,7 +295,7 @@ class DBConnect(metaclass=Singleton):
     def __str__(self):
         return ''.join([ (key + " = " + str(val) + "\n")
                             for (key, val) in list(self.__dict__.items())])
-            
+
     def connect(self, empty_sqlite_db=False):
         '''
         Attempts to create a new connection to the specified database using
@@ -305,11 +305,11 @@ class DBConnect(metaclass=Singleton):
           properties.image_csv_file and properties.object_csv_file
         '''
         connID = threading.currentThread().getName()
-        
+
         logging.info('[%s] Connecting to the database...'%(connID))
         # If this connection ID already exists print a warning
         if connID in self.connections:
-            if self.connectionInfo[connID] == (p.db_host, p.db_user, 
+            if self.connectionInfo[connID] == (p.db_host, p.db_user,
                                                (p.db_passwd or None), p.db_name):
                 logging.warn('A connection already exists for this thread. %s as %s@%s (connID = "%s").'%(p.db_name, p.db_user, p.db_host, connID))
             else:
@@ -320,11 +320,11 @@ class DBConnect(metaclass=Singleton):
             import MySQLdb
             from MySQLdb.cursors import SSCursor
             try:
-                conn = MySQLdb.connect(host=p.db_host, db=p.db_name, 
+                conn = MySQLdb.connect(host=p.db_host, db=p.db_name,
                                        user=p.db_user, passwd=(p.db_passwd or None))
                 self.connections[connID] = conn
                 self.cursors[connID] = SSCursor(conn)
-                self.connectionInfo[connID] = (p.db_host, p.db_user, 
+                self.connectionInfo[connID] = (p.db_host, p.db_user,
                                                (p.db_passwd or None), p.db_name)
                 logging.debug('[%s] Connected to database: %s as %s@%s'%(connID, p.db_name, p.db_user, p.db_host))
                 if connID == 'MainThread':
@@ -334,11 +334,11 @@ class DBConnect(metaclass=Singleton):
                         self.CreateObjectCheckedTable()
             except DBError() as e:
                 raise DBException('Failed to connect to database: %s as %s@%s (connID = "%s").\n  %s'%(p.db_name, p.db_user, p.db_host, connID, e))
-            
+
         # SQLite database: create database from CSVs
         elif p.db_type.lower() == 'sqlite':
             import sqlite3 as sqlite
-            
+
             if not p.db_sqlite_file:
                 # Compute a UNIQUE database name for these files
                 import hashlib
@@ -364,7 +364,7 @@ class DBConnect(metaclass=Singleton):
                     obtime = os.stat(p.object_csv_file).st_mtime
                     l = '%s%s%s%s'%(p.image_csv_file,p.object_csv_file,imtime,obtime)
                     dbname = 'CPA_DB_%s.db'%(hashlib.md5(l.encode()).hexdigest())
-                    
+
                 p.db_sqlite_file = os.path.join(dbpath, dbname)
             logging.info('[%s] SQLite file: %s'%(connID, p.db_sqlite_file))
             self.connections[connID] = sqlite.connect(p.db_sqlite_file)
@@ -417,7 +417,7 @@ class DBConnect(metaclass=Singleton):
             self.connections[connID].create_function("REGEXP", 2, regexp)
             # Create classifier function
             self.connections[connID].create_function('classifier', -1, self.sqlite_classifier.classify)
-            
+
             try:
                 # Try the connection
                 if empty_sqlite_db:
@@ -466,7 +466,7 @@ class DBConnect(metaclass=Singleton):
         self.cursors = {}
         self.connectionInfo = {}
         self.classifierColNames = None
-    
+
     def CloseConnection(self, connID=None):
         if not connID:
             connID = threading.currentThread().getName()
@@ -501,10 +501,10 @@ class DBConnect(metaclass=Singleton):
             cursor = self.cursors[connID]
         except KeyError as e:
             raise DBException('No such connection: "%s".\n' %(connID))
-        
+
         # Finally make the query
         try:
-            if verbose and not silent: 
+            if verbose and not silent:
                 logging.debug('[%s] %s'%(connID, query))
             if p.db_type.lower() == 'sqlite':
                 assert args is None
@@ -526,7 +526,7 @@ class DBConnect(metaclass=Singleton):
                                   '\nQuery was: "%s"'
                                   '\nFirst exception was: %s'
                                   '\nSecond exception was: %s'%(connID, query, e, e2))
-            
+
     def Commit(self):
         connID = threading.currentThread().getName()
         try:
@@ -565,8 +565,8 @@ class DBConnect(metaclass=Singleton):
         #XXX: This doesn't work for SQLite... no cursor.description_flags
         cursor = self.cursors[threading.currentThread().getName()]
         descr = []
-        for (name, type_code, display_size, internal_size, precision, 
-             scale, null_ok), flags in zip(cursor.description, 
+        for (name, type_code, display_size, internal_size, precision,
+             scale, null_ok), flags in zip(cursor.description,
                                            cursor.description_flags):
             conversion = cursor.connection.converter[type_code]
             if isinstance(conversion, list):
@@ -597,7 +597,7 @@ class DBConnect(metaclass=Singleton):
                 break
             records.extend(list(r))
         return np.array(records, dtype=self.result_dtype())
-    
+
     def GetObjectIDAtIndex(self, imKey, index):
         '''
         Returns the true object ID of the nth object in an image.
@@ -649,8 +649,8 @@ class DBConnect(metaclass=Singleton):
 
     def GetPerImageObjectCounts(self):
         '''
-        Returns a list of (imKey, obCount) tuples. 
-        The counts returned correspond to images that are present in BOTH the 
+        Returns a list of (imKey, obCount) tuples.
+        The counts returned correspond to images that are present in BOTH the
         per_image and per_object table.
         '''
         if p.object_table is None or p.object_id is None:
@@ -665,36 +665,59 @@ class DBConnect(metaclass=Singleton):
         for r in result1:
             counts[r[:-1]] = r[-1]
         return [r+(counts[r],) for r in result2 if r in counts]
-    
+
     def GetAllImageKeys(self):
         ''' Returns a list of all image keys in the image_table. '''
         select = "SELECT "+UniqueImageClause()+" FROM "+p.image_table+" GROUP BY "+UniqueImageClause()
         return self.execute(select)
-    
+
     def GetObjectsFromImage(self, imKey):
         return self.execute('SELECT %s FROM %s WHERE %s'%(UniqueObjectClause(), p.object_table, GetWhereClauseForImages([imKey])))
-    
+
     def GetObjectCoords(self, obKey, none_ok=False, silent=False):
-        '''Returns the specified object's x, y coordinates in an image.
+        '''Returns the specified object's x, y, z coordinates in an image.
         '''
-        res = self.execute('SELECT %s, %s FROM %s WHERE %s'%(
-                        p.cell_x_loc, p.cell_y_loc, p.object_table, 
-                        GetWhereClauseForObjects([obKey])), silent=silent)
+        if p.cell_z_loc:
+            res = self.execute('SELECT %s, %s, %s FROM %s WHERE %s'%(
+                            p.cell_x_loc, p.cell_y_loc, p.cell_z_loc, p.object_table,
+                            GetWhereClauseForObjects([obKey])), silent=silent)
+            reslist = [list(coord) for coord in res] #tuples are immutable so first make tuple of tuples a list of lists
+            reslist[0][2]=round(reslist[0][2]) #round to get z slice
+            #reslist[0][2]=4
+            restup = [tuple(coord) for coord in reslist] #then convert back to list of tuples
+            res = tuple(restup) #convert to tuple of tuples
+        else:
+            res = self.execute('SELECT %s, %s FROM %s WHERE %s'%(
+                            p.cell_x_loc, p.cell_y_loc, p.object_table,
+                            GetWhereClauseForObjects([obKey])), silent=silent)
+
+            #print(len(elm))
+        # for elm in res:
+        #     print("inside get ObjCoords", elm)
         if len(res) == 0 or res[0][0] is None or res[0][1] is None:
             message = ('Failed to load coordinates for object key %s. This may '
                        'indicate a problem with your per-object table.\n'
                        'You can check your per-object table "%s" in TableViewer'
-                       %(', '.join(['%s:%s'%(col, val) for col, val in 
-                                    zip(object_key_columns(), obKey)]), 
+                       %(', '.join(['%s:%s'%(col, val) for col, val in
+                                    zip(object_key_columns(), obKey)]),
                        p.object_table))
             raise Exception(message)
         else:
             return res[0]
 
     def GetObjectsCoords(self, obKeys, none_ok=False, silent=False):
-        '''Returns the specified objects' x, y coordinates in an image.
+        '''Returns the specified objects' x, y, z coordinates in an image.
         '''
-        res = self.execute('SELECT %s, %s, %s, %s FROM %s WHERE %s'%(
+        if p.cell_z_loc:
+            res = self.execute('SELECT %s, %s, %s, %s, %s FROM %s WHERE %s'%(
+                        p.image_id, p.object_id, p.cell_x_loc, p.cell_y_loc, p.cell_z_loc, p.object_table,
+                        GetWhereClauseForObjects(obKeys)), silent=silent)
+            reslist = [list(coord) for coord in res] #tuples are immutable so first make tuple of tuples a list of lists
+            reslist[0][2]=round(reslist[0][2]) #round to get z slice
+            restup = [tuple(coord) for coord in reslist] #then convert back to list of tuples
+            res = tuple(restup) #convert to tuple of tuples
+        else:
+            res = self.execute('SELECT %s, %s, %s, %s FROM %s WHERE %s'%(
                         p.image_id, p.object_id, p.cell_x_loc, p.cell_y_loc, p.object_table,
                         GetWhereClauseForObjects(obKeys)), silent=silent)
         if len(res) == 0 or res[0][0] is None or res[0][1] is None:
@@ -714,10 +737,13 @@ class DBConnect(metaclass=Singleton):
             for key in obKeys:
                 buffer.append(res_dict[key])
             return buffer
-    
-    def GetAllObjectCoordsFromImage(self, imKey):
-        ''' Returns a list of lists x, y coordinates for all objects in the given image. '''
-        select = 'SELECT '+p.cell_x_loc+', '+p.cell_y_loc+' FROM '+p.object_table+' WHERE '+GetWhereClauseForImages([imKey])+' ORDER BY '+p.object_id
+
+    def GetAllObjectCoordsFromImage(self, imKey, z=None):
+        ''' Returns a list of lists x, y, z coordinates for all objects in the given image. '''
+        if z:
+            select = 'SELECT '+p.cell_x_loc+', '+p.cell_y_loc+','+p.cell_z_loc+' FROM '+p.object_table+' WHERE '+GetWhereClauseForImages([imKey])+' ORDER BY '+p.object_id
+        else:
+            select = 'SELECT '+p.cell_x_loc+', '+p.cell_y_loc+' FROM '+p.object_table+' WHERE '+GetWhereClauseForImages([imKey])+' ORDER BY '+p.object_id
         return self.execute(select)
 
     def GetObjectNear(self, imkey, x, y, silent=False):
@@ -731,14 +757,14 @@ class DBConnect(metaclass=Singleton):
             return None
         else:
             return res[0]
-    
+
     def GetFullChannelPathsForImage(self, imKey):
-        ''' 
+        '''
         Returns a list of image channel filenames for a particular image
         including the absolute path.
         '''
         assert len(p.image_path_cols) == len(p.image_file_cols), "Number of image_path_cols and image_file_cols do not match!"
-        
+
         nChannels = len(p.image_path_cols)
         select = 'SELECT '
         for i in range(nChannels):
@@ -770,7 +796,7 @@ class DBConnect(metaclass=Singleton):
         """
         Return a tuple of (1) a dictionary mapping image keys to
         group keys and (2) a list of column names for the group
-        keys. 
+        keys.
 
         If reverse is set to true, the dictionary will map
         group keys to image keys instead.
@@ -794,7 +820,7 @@ class DBConnect(metaclass=Singleton):
             raise DBException('Group query failed for group "%s". Check the SQL'
                               ' syntax in your properties file.\n'
                               'Error was: "%s"'%(group, e))
-        
+
         col_names = self.GetResultColumnNames()[key_size:]
         from_clause = query[from_idx+6 : where_idx].strip()
         if ',' not in from_clause and ' ' not in from_clause:
@@ -818,7 +844,7 @@ class DBConnect(metaclass=Singleton):
             else:
                 d[row[:key_size]] = row[key_size:]
         return d, col_names
-    
+
     def filter_sql(self, filter_name):
         f = p._filters[filter_name]
         from . import sqltools
@@ -833,7 +859,7 @@ class DBConnect(metaclass=Singleton):
             else:
                 select_name = UniqueImageClause()
             return 'SELECT %s FROM %s WHERE %s' % (select_name,
-                                                   ','.join(unique_tables), 
+                                                   ','.join(unique_tables),
                                                    str(f))
         elif isinstance(f, sqltools.OldFilter):
             return str(f)
@@ -922,28 +948,28 @@ class DBConnect(metaclass=Singleton):
         '''
         if p.db_type.lower()=='mysql':
             res = self.execute('SHOW TABLES')
-            return [t[0] for t in res] 
+            return [t[0] for t in res]
         elif p.db_type.lower()=='sqlite':
             res = self.execute('SELECT name FROM sqlite_master WHERE type="table" ORDER BY name')
-            return [t[0] for t in res] 
+            return [t[0] for t in res]
 
     def get_other_table_names(self):
         '''
         returns a list of table names in the database that CPA hasn't accessed.
         '''
-        tables = list(set(self.GetTableNames()) - 
+        tables = list(set(self.GetTableNames()) -
                       set([p.image_table, p.object_table]))
         return sorted(tables)
-        
+
     def GetColumnNames(self, table):
         '''Returns a list of the column names for the specified table. '''
         # NOTE: SQLite doesn't like DESCRIBE or SHOW statements so we do it this way.
         self.execute('SELECT * FROM %s LIMIT 1'%(table))
         return self.GetResultColumnNames()   # return the column names
-    
 
-    
-    
+
+
+
     #
     # Methods used for linking database tables
     #
@@ -962,15 +988,15 @@ class DBConnect(metaclass=Singleton):
     # +-----------------------------------+
     # | per_im | per_well | plate | plate |
     # | per_im | per_well | well  | well  |
-    # 
-    
+    #
+
     def _add_link_tables_row(self, src, dest, link, order):
         '''adds src, dest, link, order to link_tables_table.
         '''
         self.execute('INSERT INTO %s (src, dest, link, ord) '
                      'VALUES ("%s", "%s", "%s", "%d")'
                      %(p.link_tables_table, src, dest, link, order))
-        
+
     def _add_link_columns_row(self, src, dest, col1, col2):
         '''adds src, dest, col1, col2 to link_columns_table
         '''
@@ -984,21 +1010,21 @@ class DBConnect(metaclass=Singleton):
         return [r[0] for r in self.execute('SELECT DISTINCT dest FROM %s '
                                            'WHERE src="%s"'
                                            %(p.link_tables_table, table))]
-        
+
     def adjacent_tables(self, table):
         '''return tables directly connected to the given table
         '''
         return [r[0] for r in self.execute('SELECT DISTINCT link FROM %s '
                                            'WHERE src="%s" AND ord=0'
                                            %(p.link_tables_table, table))]
-        
+
     def adjacent(self, table1, table2):
         '''return whether the given tables are adjacent
         '''
         return table1 in self.adjacent_tables(table2)
-        
+
     def do_link_tables(self, src, dest, src_cols, dest_cols):
-        '''Inserts table linking information into the database so src can 
+        '''Inserts table linking information into the database so src can
         be linked to dest through the columns specified.
         src - table to be linked in
         dest - table to link src to
@@ -1006,7 +1032,7 @@ class DBConnect(metaclass=Singleton):
         dest_cols - foreign key column names in dest
         '''
         assert len(src_cols) == len(dest_cols), 'Column lists were not the same length.'
-        
+
         # create the tables if they don't exist
         if p.link_tables_table.lower() not in [x.lower() for x in self.GetTableNames()]:
             self.execute('CREATE TABLE %s (src VARCHAR(100), '
@@ -1016,12 +1042,12 @@ class DBConnect(metaclass=Singleton):
             self.execute('CREATE TABLE %s (table1 VARCHAR(100), '
                     'table2 VARCHAR(100), col1 VARCHAR(200), col2 VARCHAR(200))'
                     %(p.link_columns_table))
-            
+
         if self.get_linking_tables(src, dest) is not None:
             raise Exception('Tables are already linked. Call '
                 'DBConnect.get_linking_tables to check if tables are linked '
                 'before do_link_tables.')
-        
+
         # Connect src directly to dest
         self._add_link_tables_row(src, dest, dest, 0)
         for col1, col2 in zip(src_cols, dest_cols):
@@ -1036,14 +1062,14 @@ class DBConnect(metaclass=Singleton):
                 link = row[2]
                 order = int(row[3]) + 1
                 self._add_link_tables_row(src, t, link, order)
-        
+
         # Connect dest back to src
         self._add_link_tables_row(dest, src, src, 0)
         for col1, col2 in zip(src_cols, dest_cols):
             self._add_link_columns_row(dest, src, col2, col1)
 
         self.Commit()
-        
+
     #
     # TODO: ensure this table wasn't linking others together.
     #
@@ -1055,17 +1081,17 @@ class DBConnect(metaclass=Singleton):
         self.execute('DELETE FROM %s WHERE table1=%s OR table2=%s'
                      %(p.link_columns_table, table, table))
         self.Commit()
-            
+
     def get_linking_expressions(self, tables):
-        '''returns: A list of Expressions linking the tables given. These 
+        '''returns: A list of Expressions linking the tables given. These
         expressions may link through some intermediate table if a path exists.
-        
+
         Use when constructing a where clause for a multi-table query.
-                 
+
         An exception is raised if a path linking the tables doesn't exist. Call
         DBConnect.get_linking_tables first to check that all tables are linked.
-                 
-        usage: 
+
+        usage:
         get_linking_expressions(['per_well', 'per_image', 'per_object'])
         [Expression(('per_well', 'Plate'), '=', ('per_image', 'Plate')),
          Expression(('per_well', 'Well'),  '=', ('per_image', 'Well')),
@@ -1075,23 +1101,23 @@ class DBConnect(metaclass=Singleton):
         for t in tables[1:]:
             if self.get_linking_table_pairs(tables[0], t) is None:
                 raise Exception('Tables "%s" and "%s" are not linked.'%(tables[0], t))
-            
+
         def get_linking_clauses(table1, table2):
             #helper function returns expressions that link 2 tables
             return [sql.Expression(sql.Column(ta, cola), '=', sql.Column(tb, colb))
                     for ta, tb in self.get_linking_table_pairs(table1, table2)
                     for cola, colb in self.get_linking_columns(ta, tb)]
-        
+
         expressions = set()
         for table in tables[1:]:
             expressions.update(get_linking_clauses(tables[0], table))
         return expressions
-    
+
     def get_linking_tables(self, table_from, table_to):
         '''returns: an ordered list of tables that must be used to join
         table_from to table_to. If the tables aren't linked in link_tables_table
         then None is returned.
-        
+
         usage:
         get_linking_tables(per_well, per_object)
         [per_image, per_object]
@@ -1102,16 +1128,16 @@ class DBConnect(metaclass=Singleton):
                           'WHERE src="%s" AND dest="%s" ORDER BY ord'
                           %(p.link_tables_table, table_from, table_to))
 
-        return [row[0] for row in res] or None 
-    
+        return [row[0] for row in res] or None
+
     def get_linking_table_pairs(self, table_from, table_to):
-        '''returns: an ordered list of table pairs that must be used to join 
+        '''returns: an ordered list of table pairs that must be used to join
         table_from to table_to. If the tables aren't linked in link_tables_table
         then None is returned.
-        
+
         usage:
         get_linking_table_pairs(per_well, per_object)
-        [(per_well, per_image), (per_image, per_object)]        
+        [(per_well, per_image), (per_image, per_object)]
         '''
         ltables = self.get_linking_tables(table_from, table_to)
         if ltables is None:
@@ -1119,10 +1145,10 @@ class DBConnect(metaclass=Singleton):
         from_tables = [table_from] + [t for t in ltables[:-1]]
         to_tables = ltables
         return [(tfrom, tto) for tfrom, tto in zip(from_tables, to_tables)]
-    
+
     def get_linking_columns(self, table_from, table_to):
-        '''returns: a list of column pairs that can be used to join table_from 
-                 to table_to. An exception is raised if table_from is not 
+        '''returns: a list of column pairs that can be used to join table_from
+                 to table_to. An exception is raised if table_from is not
                  DIRECTLY linked to table_to in link_tables_table or if the
                  link_columns_table is not found.
 
@@ -1137,18 +1163,18 @@ class DBConnect(metaclass=Singleton):
             raise Exception('Tables "%s" and "%s" are not directly linked in '
                             'the database'%(table_from, table_to))
         return col_pairs
-        
+
     def get_linkable_tables(self):
         '''returns the list of tables that CPA can link together.
         '''
         tables = []
         if p.link_tables_table in self.GetTableNames():
-            tables = [row[0] for row in 
+            tables = [row[0] for row in
                       self.execute('SELECT DISTINCT src FROM %s'
                                    %(p.link_tables_table))]
         if len(tables) == 0:
             if p.object_table:
-                self.do_link_tables(p.image_table, p.object_table, 
+                self.do_link_tables(p.image_table, p.object_table,
                                     image_key_columns(), image_key_columns())
                 return [p.image_table, p.object_table]
             else:
@@ -1156,7 +1182,7 @@ class DBConnect(metaclass=Singleton):
         return tables
 
     def GetUserColumnNames(self, table):
-        '''Returns a list of the column names that start with "User_" for the 
+        '''Returns a list of the column names that start with "User_" for the
         specified table. '''
         return [col for col in self.GetColumnNames(table) if col.lower().startswith('user')]
 
@@ -1164,13 +1190,13 @@ class DBConnect(metaclass=Singleton):
         '''Returns python types for each column of the given table. '''
         sqltypes = self.GetColumnTypeStrings(table)
         return [sqltype_to_pythontype(t) for t in sqltypes]
-    
+
     def GetColumnType(self, table, colname):
         '''Returns the python type for a given table column. '''
         for col, coltype in zip(self.GetColumnNames(table), self.GetColumnTypes(table)):
             if col == colname:
                 return coltype
-            
+
     def GetColumnTypeStrings(self, table):
         '''Returns the SQL type string for each column of the given table.'''
         if p.db_type.lower() == 'sqlite':
@@ -1179,7 +1205,7 @@ class DBConnect(metaclass=Singleton):
         elif p.db_type.lower() == 'mysql':
             res = self.execute('SHOW COLUMNS FROM %s'%(table))
             return [r[1] for r in res]
-        
+
     def GetColumnTypeString(self, table, colname):
         '''Returns the SQL type string for a given table column. '''
         for col, coltype in zip(self.GetColumnNames(table), self.GetColumnTypeStrings(table)):
@@ -1189,9 +1215,9 @@ class DBConnect(metaclass=Singleton):
     def GetColnamesForClassifier(self, exclude_features_with_no_variance=False,
                                  force=False):
         '''
-        Returns a list of column names for the object_table excluding 
+        Returns a list of column names for the object_table excluding
         those specified in Properties.classifier_ignore_columns
-        and excluding those with zero variance (unless 
+        and excluding those with zero variance (unless
         exclude_features_with_no_variance is set to False)
         '''
         if (self.classifierColNames is None) or force:
@@ -1224,11 +1250,11 @@ class DBConnect(metaclass=Singleton):
                 # ignore columns which have no variance
                 cq = ', '.join(['MAX(%s)-MIN(%s)'%(col,col) for col in col_names])
                 res = np.array(self.execute('SELECT %s FROM %s'%(cq, p.object_table))[0])
-                ignore_cols = np.array(col_names)[np.where(res==0)[0]]                
+                ignore_cols = np.array(col_names)[np.where(res==0)[0]]
                 for colname in ignore_cols:
-                    self.classifierColNames.remove(colname)            
+                    self.classifierColNames.remove(colname)
                     logging.warning('Ignoring column "%s" because it has zero variance'%(colname))
-            
+
             if len(self.classifierColNames) == 0 and p.classifier_ignore_columns:
                 import wx
                 wx.MessageBox('No columns were found to use for classification '
@@ -1239,7 +1265,7 @@ class DBConnect(metaclass=Singleton):
                 self.classifierColNames = None
                 return None
         return self.classifierColNames
-    
+
     def GetResultColumnNames(self):
         ''' Returns the column names of the last query on this connection. '''
         connID = threading.currentThread().getName()
@@ -1311,26 +1337,26 @@ class DBConnect(metaclass=Singleton):
             return self.execute('SELECT %s, %s FROM %s'%(UniqueImageClause(), ','.join(well_key_columns()), p.image_table))
         else:
             logging.error('Both plate_id and well_id must be defined in properties!')
-    
+
     def get_platewell_for_object(self, key):
         if p.plate_id and p.well_id:
             return self.execute('SELECT %s FROM %s WHERE %s'%(','.join(well_key_columns()), p.image_table, GetWhereClauseForImages([key[:-1]])))[0]
         else:
             return key[:-1]
-    
+
     def InferColTypesFromData(self, tabledata, nCols):
         '''
         For converting csv data to DB data.
         Returns a list of column types (INT, FLOAT, or VARCHAR(#)) that each column can safely be converted to
         tabledata: 2d iterable of strings
-        nCols: # of columns  
+        nCols: # of columns
         '''
         colTypes = ['' for i in range(nCols)]
         # Maximum string length for each column (if VARCHAR)
-        maxLen   = [0 for i in range(nCols)] 
+        maxLen   = [0 for i in range(nCols)]
         try:
             tabledata[0][0]
-        except: 
+        except:
             raise Exception('Cannot infer column types from an empty table.')
         for row in tabledata:
             for i, e in enumerate(row):
@@ -1350,10 +1376,10 @@ class DBConnect(metaclass=Singleton):
                     x = str(e)
                     maxLen[i] = max(len(x), maxLen[i])
                     colTypes[i] = 'VARCHAR(%d)'%(maxLen[i])
-                except ValueError: 
+                except ValueError:
                     raise Exception('Value in table could not be converted to string!')
         return colTypes
-    
+
     def AppendColumn(self, table, colname, coltype):
         '''
         Appends a new column to the specified table.
@@ -1363,7 +1389,7 @@ class DBConnect(metaclass=Singleton):
         if not re.match('^[A-Za-z]\w*$', colname):
             raise ValueError('Column name may contain only alphanumeric characters and underscore, and must begin with a letter.')
         self.execute('ALTER TABLE %s ADD %s %s'%(table, colname, coltype))
-        
+
     def UpdateWells(self, table, colname, value, wellkeys):
         '''
         Sets the value of the specified column in the database for each row
@@ -1382,7 +1408,7 @@ class DBConnect(metaclass=Singleton):
                                                 GetWhereClauseForWells(wellkeys)))
         # for some reason non string columns need to be committed or they will not be saved
         self.Commit()
-    
+
     def CreateSQLiteDB(self):
         '''
         Creates an SQLite database from files specified in properties
@@ -1399,14 +1425,14 @@ class DBConnect(metaclass=Singleton):
 
         dtable = get_data_table_from_csv_reader(r)
         colTypes = self.InferColTypesFromData(dtable, len(columnLabels))
-        
+
         # Build the CREATE TABLE statement
         statement = 'CREATE TABLE '+p.image_table+' ('
         statement += ',\n'.join([lbl+' '+colTypes[i] for i, lbl in enumerate(columnLabels)])
         keys = ','.join([x for x in [p.table_id, p.image_id, p.object_id] if x in columnLabels])
         statement += ',\nPRIMARY KEY (' + keys + ') )'
         f.close()
-        
+
         logging.info('Creating table: %s'%(p.image_table))
         self.execute('DROP TABLE IF EXISTS %s'%(p.image_table))
         self.execute(statement)
@@ -1430,7 +1456,7 @@ class DBConnect(metaclass=Singleton):
             logging.info('Creating table: %s'%(p.object_table))
             self.execute('DROP TABLE IF EXISTS '+p.object_table)
             self.execute(statement)
-        
+
         # POPULATE THE IMAGE TABLE
         f = open(p.image_csv_file, 'U')
         r = csv.reader(f)
@@ -1444,7 +1470,7 @@ class DBConnect(metaclass=Singleton):
             except StopIteration:
                 break
         f.close()
-        
+
         # POPULATE THE OBJECT TABLE
         if not p.classification_type == 'image':
             f = open(p.object_csv_file, 'U')
@@ -1458,18 +1484,18 @@ class DBConnect(metaclass=Singleton):
                     row = next(r)
                 except StopIteration: break
             f.close()
-        
+
         self.Commit()
-        
+
     def CreateSQLiteDBFromCSVs(self):
         '''
         Creates an SQLite database from files generated by CellProfiler's
         ExportToDatabase module.
         '''
         import csv
-        
+
         imcsvs, obcsvs = get_csv_filenames_from_sql_file()
-                
+
         # Verify that the CSVs exist
         csv_dir = os.path.split(p.db_sql_file)[0] or '.'
         dir_files = os.listdir(csv_dir)
@@ -1500,10 +1526,10 @@ class DBConnect(metaclass=Singleton):
                 else:
                     in_create_stmt = True
         f.close()
-        
+
         for q in create_stmts:
             self.execute(q)
-        
+
         import wx
         if self.gui_parent is not None and issubclass(self.gui_parent.__class__, wx.Window):
             dlg = wx.ProgressDialog('Creating sqlite DB...', '0% Complete', 100, self.gui_parent, wx.PD_ELAPSED_TIME | wx.PD_ESTIMATED_TIME | wx.PD_REMAINING_TIME | wx.PD_CAN_ABORT)
@@ -1653,10 +1679,10 @@ class DBConnect(metaclass=Singleton):
         AreaShape_Area = [x for x in all_cols if 'AreaShape_Area' in x]
         if DB_TYPE == 'mysql':
             if len(AreaShape_Area) > 0:
-                query = f"""CREATE OR REPLACE VIEW {p.object_table} AS SELECT {', '.join(all_cols)} FROM {object_table} 
+                query = f"""CREATE OR REPLACE VIEW {p.object_table} AS SELECT {', '.join(all_cols)} FROM {object_table}
                 WHERE {" IS NOT NULL AND ".join(all_cols)} IS NOT NULL AND {" > 0 AND ".join(AreaShape_Area)} > 0"""
             else:
-                query = f"""CREATE OR REPLACE VIEW {p.object_table} AS SELECT {', '.join(all_cols)} FROM {object_table} 
+                query = f"""CREATE OR REPLACE VIEW {p.object_table} AS SELECT {', '.join(all_cols)} FROM {object_table}
                 WHERE {" IS NOT NULL AND ".join(all_cols)} IS NOT NULL"""
             self.execute(query)
         elif DB_TYPE == 'sqlite':
@@ -1772,9 +1798,9 @@ class DBConnect(metaclass=Singleton):
             res = self.execute("SELECT table_name FROM information_schema.tables WHERE table_name='%s' AND table_schema='%s'"%(name, p.db_name))
         else:
             res = self.execute("SELECT name FROM sqlite_master WHERE type='table' and name='%s'"%(name))
-            res += self.execute("SELECT name FROM sqlite_temp_master WHERE type='table' and name='%s'"%(name))            
+            res += self.execute("SELECT name FROM sqlite_temp_master WHERE type='table' and name='%s'"%(name))
         return len(res) > 0
-    
+
     def CreateTempTableFromCSV(self, filename, tablename):
         '''
         Reads a csv file into a temporary table in the database.
@@ -1795,13 +1821,13 @@ class DBConnect(metaclass=Singleton):
             try:
                 col = np.array(dtable[:,i], dtype=str)
                 col = np.array(dtable[:,i], dtype=float)
-                col = np.array(dtable[:,i], dtype=int) 
+                col = np.array(dtable[:,i], dtype=int)
             except:
                 pass
             typed_table += [col]
         typed_table = np.array(typed_table, dtype=object).T
         return self.CreateTempTableFromData(typed_table, colnames, tablename)
-    
+
     def create_empty_table(self, tablename, colnames, coltypes, temporary=False):
         '''Creates an empty table with the given tablename and columns.
         Note: column names will automatically be cleaned up.
@@ -1816,7 +1842,7 @@ class DBConnect(metaclass=Singleton):
             self.execute('CREATE TEMPORARY TABLE %s (%s)'%(tablename, coldefs))
 
     def create_default_indexes_on_table(self, tablename):
-        '''automatically adds indexes to all the image, object, and well key 
+        '''automatically adds indexes to all the image, object, and well key
         columns in the specified table
         '''
         for key in list(well_key_columns() or []) + list(object_key_columns()):
@@ -1837,17 +1863,17 @@ class DBConnect(metaclass=Singleton):
             vals = ', '.join(vals)
             self.execute('INSERT INTO %s (%s) VALUES (%s)'%(
                           tablename, ', '.join(colnames), vals), silent=True)
-    
+
     def CreateTempTableFromData(self, dtable, colnames, tablename, temporary=True):
         '''Creates and populates a temporary table in the database.
         '''
         return self.CreateTableFromData(dtable, colnames, tablename, temporary=temporary)
-    
+
     def CreateTableFromData(self, dtable, colnames, tablename, temporary=False, coltypes=None):
         '''Creates and populates a table in the database.
-        dtable -- array of the data to populate the table with (SQL data types 
+        dtable -- array of the data to populate the table with (SQL data types
                   are inferred from the array data)
-        colnames -- the column names to use (note: these will be cleaned up if 
+        colnames -- the column names to use (note: these will be cleaned up if
                     invalid characters are used)
         tablename -- the name of the table
         temporary -- whether the table should be created as temporary
@@ -1861,14 +1887,14 @@ class DBConnect(metaclass=Singleton):
         self.insert_rows_into_table(tablename, colnames, coltypes, dtable)
         self.Commit()
         return True
-    
+
     def is_view(self, table):
         if p.db_type == 'sqlite':
             return False
         self.execute('SHOW CREATE TABLE %s'%(table))
         res = self.GetResultColumnNames()
         return res[0].lower() == 'view'
-    
+
     def CheckTables(self):
         '''
         Queries the DB to check that the per_image and per_object
@@ -1892,7 +1918,7 @@ class DBConnect(metaclass=Singleton):
                         'severly slowed.\n'
                         'To avoid this warning, set check_tables = false in your '
                         'properties file.'%(col, p.object_table),
-                        'Missing column index', 
+                        'Missing column index',
                         style=wx.OK|wx.ICON_EXCLAMATION).ShowModal()
         else:
             logging.warn('%s is a view. CheckTables will skip the index check on this table'%(p.image_table))
@@ -1900,11 +1926,11 @@ class DBConnect(metaclass=Singleton):
         # Explicitly check for TableNumber in case it was not specified in props file
         if not p.object_table and 'TableNumber' in self.GetColumnNames(p.image_table):
             raise ValueError('Indexed column "TableNumber" was found in the database but not in your properties file.')
-        
+
         # STOP here if there is no object table
         if not p.object_table:
             return
-        
+
         if not self.is_view(p.object_table):
             # Check for index on object_table
             res = self.execute('SHOW INDEX FROM %s'%(p.object_table))
@@ -1917,11 +1943,11 @@ class DBConnect(metaclass=Singleton):
                         'severly slowed.\n'
                         'To avoid this warning, set check_tables = false in your '
                         'properties file.'%(col, p.object_table),
-                        'Missing column index', 
+                        'Missing column index',
                         style=wx.OK|wx.ICON_EXCLAMATION).ShowModal()
         else:
             logging.warn('%s is a view. CheckTables will skip the index check on this table'%(p.object_table))
-        
+
         # Explicitly check for TableNumber in case it was not specified in props file
         if ('TableNumber' not in object_key_columns()) and ('TableNumber' in self.GetColumnNames(p.object_table)):
             raise ValueError('Indexed column "TableNumber" was found in the database but not in your properties file.')
@@ -1929,7 +1955,7 @@ class DBConnect(metaclass=Singleton):
             logging.warn('TableNumber column was found indexed in your image table but not your object table.')
         elif ('TableNumber' not in object_key_columns()):
             logging.warn('TableNumber column was found indexed in your object table but not your image table.')
-        
+
         # Removed because it doesn't work (ignores TableNumber), and is slow.
         #
         # # Check for orphaned objects
@@ -1937,13 +1963,13 @@ class DBConnect(metaclass=Singleton):
         # imims = self.execute('SELECT %s FROM %s'%(p.image_id, p.image_table))
         # orphans = set(obims) - set(imims)
         # assert not orphans, 'Objects were found in "%s" that had no corresponding image key in "%s"'%(p.object_table, p.image_table)
-        
+
         # Check for unlabeled wells
         if p.well_id:
             res = self.execute('SELECT %s FROM %s WHERE %s IS NULL OR %s=""'%(UniqueImageClause(), p.image_table, p.well_id, p.well_id))
             if any(res):
                 logging.warn('WARNING: Images were found in "%s" that had a NULL or empty "%s" column value'%(p.image_table, p.well_id))
-        
+
         # Check for unlabeled plates
         if p.plate_id:
             res = self.execute('SELECT %s FROM %s WHERE %s IS NULL OR %s=""'%(UniqueImageClause(), p.image_table, p.plate_id, p.plate_id))
@@ -1974,8 +2000,8 @@ class DBConnect(metaclass=Singleton):
             max = data[0][1]
         else:
             min, max = range
-            
-        clause = ("round(%d * (%s - (%f)) / (%f - (%f)))" % 
+
+        clause = ("round(%d * (%s - (%f)) / (%f - (%f)))" %
                   (nbins, column, min, max, min))
         h = np.zeros(nbins)
         res = self.execute("select %s as bin, count(*) from %s "
@@ -2001,7 +2027,7 @@ class DBConnect(metaclass=Singleton):
     def register_gui_parent(self, parent):
         self.gui_parent = parent
 
-        
+
 class Entity(object):
     """Abstract class containing code that is common to Images and
     Objects.  Do not instantiate directly."""
@@ -2096,7 +2122,7 @@ class Entity(object):
         else:
             return "GROUP BY " + ",".join(self.group_columns)
     group_by_clause = property(_get_group_by_clause)
-    
+
     def count(self):
         c = DBConnect().execute(self.all_query(columns=["COUNT(*)"]))[0][0]
         c = max(0, c - (self._offset or 0))
@@ -2136,15 +2162,15 @@ class Entity(object):
         new = copy.deepcopy(self)
         new._columns = columns
         return new
-    
-    
+
+
 class Union(Entity):
     def __init__(self, *args):
         super(Union, self).__init__()
         self.operands = args
 
     def all_query(self, *args, **kwargs):
-        return " UNION ".join([e.all_query(*args, **kwargs) 
+        return " UNION ".join([e.all_query(*args, **kwargs)
                                for e in self.operands])
 
 class Images(Entity):
@@ -2179,7 +2205,7 @@ class Images(Entity):
     def columns(self):
         return self._columns or DBConnect().GetColumnNames(Properties().image_table)
 
-    
+
 class Objects(Entity):
     '''
     Easy access to objects.
@@ -2220,7 +2246,7 @@ class Objects(Entity):
         Offsets and limits are ignored here, not sure if they should be."""
         db = DBConnect()
         return db.execute("SELECT %s FROM %s %s"%(
-                ",".join(["STD(%s)" % c 
+                ",".join(["STD(%s)" % c
                           for c in db.GetColnamesForClassifier()]),
                 self.from_clause, self.where_clause))[0]
 

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -685,7 +685,6 @@ class DBConnect(metaclass=Singleton):
             reslist = [list(coord) for coord in res] #tuples are immutable so first make tuple of tuples a list of lists
             try:
                 reslist[0][2]=round(reslist[0][2]) #round to get z slice
-                print(reslist)
                 restup = [tuple(coord) for coord in reslist] #then convert back to list of tuples
                 res = tuple(restup) #convert to tuple of tuples
             except:

--- a/cpa/imagereader.py
+++ b/cpa/imagereader.py
@@ -61,6 +61,9 @@ class ImageReader(object):
                 logging.info('ImageIO: Loading image from "%s"' % filename_or_url)
             try:
                 if p.process_3D and z is not None:
+                    if z == "mid":
+                        image = imageio.mimread(filename_or_url, memtest=False)
+                        z = round(len(image)/2)
                     return imageio.mimread(filename_or_url, memtest=False)[z]
                 else:
                     return imageio.imread(filename_or_url)

--- a/cpa/imagereader.py
+++ b/cpa/imagereader.py
@@ -61,6 +61,7 @@ class ImageReader(object):
                 logging.info('ImageIO: Loading image from "%s"' % filename_or_url)
             try:
                 if z:
+                    #print("z inside of _readImage ", z)
                     return imageio.mimread(filename_or_url)[z]
                 else:
                     return imageio.imread(filename_or_url)

--- a/cpa/imagereader.py
+++ b/cpa/imagereader.py
@@ -60,8 +60,7 @@ class ImageReader(object):
             if log_io:
                 logging.info('ImageIO: Loading image from "%s"' % filename_or_url)
             try:
-                if z:
-                    #print("z inside of _readImage ", z)
+                if p.process_3D and z is not None:
                     return imageio.mimread(filename_or_url)[z]
                 else:
                     return imageio.imread(filename_or_url)
@@ -77,7 +76,7 @@ class ImageReader(object):
         if log_io:
             logging.info('BioFormats: Loading image from "%s"' % filename_or_url)
         try:
-            if z:
+            if p.process_3D and z is not None:
                 return bioformats.load_image(filename_or_url, rescale=False, z=z)
             else:
                 return bioformats.load_image(filename_or_url, rescale=False)

--- a/cpa/imagereader.py
+++ b/cpa/imagereader.py
@@ -17,13 +17,13 @@ class ThrowingURLopener(urllib.request.URLopener):
 
 class ImageReader(object):
 
-    def ReadImages(self, fds, log_io=True):
+    def ReadImages(self, fds, log_io=True, z=None):
         '''fds -- list of file descriptors (filenames or urls)
         returns a list of channels as numpy float32 arrays
         '''
         channels = []
         for i, filename_or_url in enumerate(fds):
-            image = self._read_image(filename_or_url, log_io=log_io)
+            image = self._read_image(filename_or_url, log_io=log_io, z=z)
             if image is None:
                 return
             channels += self._extract_channels(filename_or_url, image,
@@ -42,7 +42,7 @@ class ImageReader(object):
 
         return channels
 
-    def _read_image(self, filename_or_url, log_io=True):
+    def _read_image(self, filename_or_url, log_io=True, z=None):
         if p.image_url_prepend:
             parsed = urllib.parse.urlparse(p.image_url_prepend + filename_or_url)
             if parsed.scheme:
@@ -60,7 +60,10 @@ class ImageReader(object):
             if log_io:
                 logging.info('ImageIO: Loading image from "%s"' % filename_or_url)
             try:
-                return imageio.imread(filename_or_url)
+                if z:
+                    return imageio.mimread(filename_or_url)[z]
+                else:
+                    return imageio.imread(filename_or_url)
             except FileNotFoundError:
                 logging.error(f"File not found: {filename_or_url}")
                 return
@@ -73,7 +76,10 @@ class ImageReader(object):
         if log_io:
             logging.info('BioFormats: Loading image from "%s"' % filename_or_url)
         try:
-            return bioformats.load_image(filename_or_url, rescale=False)
+            if z:
+                return bioformats.load_image(filename_or_url, rescale=False, z=z)
+            else:
+                return bioformats.load_image(filename_or_url, rescale=False)
         except FileNotFoundError:
             logging.error(f"File not found: {filename_or_url}")
         except:

--- a/cpa/imagereader.py
+++ b/cpa/imagereader.py
@@ -61,7 +61,7 @@ class ImageReader(object):
                 logging.info('ImageIO: Loading image from "%s"' % filename_or_url)
             try:
                 if p.process_3D and z is not None:
-                    return imageio.mimread(filename_or_url)[z]
+                    return imageio.mimread(filename_or_url, memtest=False)[z]
                 else:
                     return imageio.imread(filename_or_url)
             except FileNotFoundError:

--- a/cpa/imagetile.py
+++ b/cpa/imagetile.py
@@ -116,6 +116,8 @@ class ImageTile(ImagePanel):
                 coords = db.GetObjectCoords(obKey)
                 if len(list(coords))==3:
                     z=coords[2]
+                else:
+                    z=None
                 imViewer = imagetools.ShowImage(obKey[:-1], self.chMap[:], parent=self.classifier,
                                         brightness=self.brightness, contrast=self.contrast,
                                         scale=1, z=z)
@@ -181,6 +183,8 @@ class ImageTile(ImagePanel):
         coords = db.GetObjectCoords(self.obKey)
         if len(list(coords))==3:
             z=coords[2]
+        else:
+            z=None
         imViewer = imagetools.ShowImage(self.obKey[:-1], list(self.chMap), parent=self.classifier,
                                         brightness=self.brightness, contrast=self.contrast,
                                         scale=1, z=z)

--- a/cpa/imagetile.py
+++ b/cpa/imagetile.py
@@ -178,9 +178,12 @@ class ImageTile(ImagePanel):
             dlg.ShowModal()
 
     def OnDClick(self, evt):
+        coords = db.GetObjectCoords(self.obKey)
+        if len(list(coords))==3:
+            z=coords[2]
         imViewer = imagetools.ShowImage(self.obKey[:-1], list(self.chMap), parent=self.classifier,
                                         brightness=self.brightness, contrast=self.contrast,
-                                        scale=1)
+                                        scale=1, z=z)
         if imViewer and self.bin.label != 'image gallery':
             imViewer.imagePanel.SelectPoint(db.GetObjectCoords(self.obKey)[0:2])
 

--- a/cpa/imagetile.py
+++ b/cpa/imagetile.py
@@ -20,7 +20,7 @@ class ImageTileDropTarget(wx.DropTarget):
         self.data = wx.CustomDataObject("application.cpa.ObjectKey")
         wx.DropTarget.__init__(self, self.data)
         self.tile = tile
-    
+
     def OnData(self, x, y, dragres):
         if not self.GetData():
             return wx.DragNone
@@ -28,17 +28,17 @@ class ImageTileDropTarget(wx.DropTarget):
         srcID, obKeys = pickle.loads(draginfo)
         if not obKeys:
             return wx.DragNone
-        return self.tile.bin.ReceiveDrop(srcID, obKeys) 
+        return self.tile.bin.ReceiveDrop(srcID, obKeys)
 
 class ImageTile(ImagePanel):
     '''
     ImageTiles are thumbnail images that can be dragged and dropped
     between SortBins.
     '''
-    def __init__(self, bin, obKey, images, chMap, selected=False, 
+    def __init__(self, bin, obKey, images, chMap, selected=False,
                  scale=1.0, brightness=1.0, contrast=None, display_whole_image=False):
 
-        ImagePanel.__init__(self, images, chMap, bin, scale=scale, 
+        ImagePanel.__init__(self, images, chMap, bin, scale=scale,
                             brightness=brightness, contrast=contrast, display_whole_image=display_whole_image)
         self.SetDropTarget(ImageTileDropTarget(self))
 
@@ -100,12 +100,12 @@ class ImageTile(ImagePanel):
             self.popupItemIndexById[id] = i
             self.popupMenu.Append(id,item)
         self.popupMenu.Bind(wx.EVT_MENU,self.OnSelectFromPopupMenu)
-        
+
     def OnRightDown(self, evt):
         ''' On right click show popup menu. '''
         self.CreatePopupMenu()
         self.PopupMenu(self.popupMenu, evt.GetPosition())
-    
+
     def OnSelectFromPopupMenu(self, evt):
         ''' Handles selections from the popup menu. '''
         choice = self.popupItemIndexById[evt.GetId()]
@@ -116,7 +116,7 @@ class ImageTile(ImagePanel):
                                         brightness=self.brightness, contrast=self.contrast,
                                         scale=1)
                 if self.bin.label != 'image gallery':
-                    imViewer.imagePanel.SelectPoint(db.GetObjectCoords(obKey))
+                    imViewer.imagePanel.SelectPoint(db.GetObjectCoords(obKey)[0:2])
                 #imViewer.imagePanel.SetPosition((-db.GetObjectCoords(obKey)[0]+imViewer.Size[0]/2, -db.GetObjectCoords(obKey)[1]+imViewer.Size[1]/2))
 
         elif choice == 1:
@@ -131,7 +131,7 @@ class ImageTile(ImagePanel):
             if self.classifier is not None and self.bin.label == 'unclassified':
                 self.DisplayProbs()
             elif self.bin.label == 'image gallery':
-                self.DisplayObjects()                
+                self.DisplayObjects()
 
     def DisplayObjects(self):
         if self.bin.SelectedKeys():
@@ -146,7 +146,7 @@ class ImageTile(ImagePanel):
             wx.CallAfter(cb)
         else:
             import logging
-            logging.info("No image selected. Please select an image first.")            
+            logging.info("No image selected. Please select an image first.")
 
     def DisplayProbs(self):
         try:
@@ -162,7 +162,7 @@ class ImageTile(ImagePanel):
 
                     values = [get_data(k)]
                     y_score = []
-                    y_score = clf.PredictProba(values)        
+                    y_score = clf.PredictProba(values)
 
                     y_score = y_score[0] # Flatten array
                     self.classifier.PlotProbs(y_score, key=k)
@@ -172,14 +172,14 @@ class ImageTile(ImagePanel):
         except:
             dlg = wx.MessageDialog(self,'Sorry. The selected classifier does not provide this functionality', 'No probability scores available', style=wx.OK)
             dlg.ShowModal()
-        
+
     def OnDClick(self, evt):
         imViewer = imagetools.ShowImage(self.obKey[:-1], list(self.chMap), parent=self.classifier,
                                         brightness=self.brightness, contrast=self.contrast,
                                         scale=1)
         if imViewer and self.bin.label != 'image gallery':
-            imViewer.imagePanel.SelectPoint(db.GetObjectCoords(self.obKey))
-        
+            imViewer.imagePanel.SelectPoint(db.GetObjectCoords(self.obKey)[0:2])
+
     def Select(self):
         if not self.selected:
             self.selected = True
@@ -189,13 +189,13 @@ class ImageTile(ImagePanel):
         if self.selected:
             self.selected = False
             self.Refresh()
-    
+
     def ToggleSelect(self):
         if self.selected:
             self.Deselect()
         else:
             self.Select()
-    
+
     def OnLeftDown(self, evt):
         self.bin.SetFocusIgnoringChildren()
         self.leftPressed = True
@@ -216,16 +216,16 @@ class ImageTile(ImagePanel):
             # Handle resetting selection in the sortbin
             self.bin.selectbox = None
             self.bin.Refresh()
-            
+
     def OnMouseOver(self, evt):
         self.showCenter = True
         self.Refresh()
-        
+
     def OnMouseOut(self, evt):
         self.showCenter = False
         self.leftPressed = False
         self.Refresh()
-            
+
     def OnMotion(self, evt):
         if self.bin.dragging:
             # A tile has captured a motion event we want to use with sortbin drag selection.
@@ -266,4 +266,3 @@ class ImageTile(ImagePanel):
     def OnSize(self, evt):
         self.SetClientSize(evt.GetSize())
         evt.Skip()
-

--- a/cpa/imagetile.py
+++ b/cpa/imagetile.py
@@ -112,11 +112,15 @@ class ImageTile(ImagePanel):
         if choice == 0:
             for obKey in self.bin.SelectedKeys():
                 #View full images of selected
+                #get coordinates of object (inc z if there)
+                coords = db.GetObjectCoords(obKey)
+                if len(list(coords))==3:
+                    z=coords[2]
                 imViewer = imagetools.ShowImage(obKey[:-1], self.chMap[:], parent=self.classifier,
                                         brightness=self.brightness, contrast=self.contrast,
-                                        scale=1)
+                                        scale=1, z=z)
                 if self.bin.label != 'image gallery':
-                    imViewer.imagePanel.SelectPoint(db.GetObjectCoords(obKey)[0:2])
+                    imViewer.imagePanel.SelectPoint(coords[0:2])
                 #imViewer.imagePanel.SetPosition((-db.GetObjectCoords(obKey)[0]+imViewer.Size[0]/2, -db.GetObjectCoords(obKey)[1]+imViewer.Size[1]/2))
 
         elif choice == 1:

--- a/cpa/imagetile.py
+++ b/cpa/imagetile.py
@@ -180,9 +180,12 @@ class ImageTile(ImagePanel):
             dlg.ShowModal()
 
     def OnDClick(self, evt):
-        coords = db.GetObjectCoords(self.obKey)
-        if len(coords)==3:
-            z=coords[2]
+        if self.obKey[1]!=-1:
+            coords = db.GetObjectCoords(self.obKey)
+            if len(coords)==3:
+                z=coords[2]
+            else:
+                z=None
         else:
             z=None
         imViewer = imagetools.ShowImage(self.obKey[:-1], list(self.chMap), parent=self.classifier,
@@ -190,6 +193,7 @@ class ImageTile(ImagePanel):
                                         scale=1, z=z)
         if imViewer and self.bin.label != 'image gallery':
             imViewer.imagePanel.SelectPoint(db.GetObjectCoords(self.obKey)[0:2])
+            
 
     def Select(self):
         if not self.selected:

--- a/cpa/imagetile.py
+++ b/cpa/imagetile.py
@@ -114,7 +114,7 @@ class ImageTile(ImagePanel):
                 #View full images of selected
                 #get coordinates of object (inc z if there)
                 coords = db.GetObjectCoords(obKey)
-                if len(list(coords))==3:
+                if len(coords)==3:
                     z=coords[2]
                 else:
                     z=None
@@ -181,7 +181,7 @@ class ImageTile(ImagePanel):
 
     def OnDClick(self, evt):
         coords = db.GetObjectCoords(self.obKey)
-        if len(list(coords))==3:
+        if len(coords)==3:
             z=coords[2]
         else:
             z=None

--- a/cpa/imagetools.py
+++ b/cpa/imagetools.py
@@ -30,7 +30,7 @@ def FetchTile(obKey, display_whole_image=False, z=None):
     pos = list(db.GetObjectCoords(obKey))
     if(len(pos)==3):
         z=pos[2]
-    print('z is',z)
+    #print('z is',z)
     imgs = FetchImage(imKey, z=z)
     if imgs is None:
         # Loading failed, return gracefully.
@@ -61,7 +61,7 @@ def FetchTile(obKey, display_whole_image=False, z=None):
 
 def FetchImage(imKey, z=None):
     global cachedkeys
-    if imKey in cache:
+    if imKey in cache and z is None:
         return cache[imKey]
     else:
         ir = ImageReader()
@@ -75,7 +75,8 @@ def FetchImage(imKey, z=None):
             # Loading failed
             return
         cache[imKey] = imgs
-        cachedkeys += [imKey]
+        if imKey not in cachedkeys: #only add the key if it's new
+            cachedkeys += [imKey]
         while len(cachedkeys) > int(p.image_buffer_size):
             del cache[cachedkeys.pop(0)]
         return cache[imKey]

--- a/cpa/imagetools.py
+++ b/cpa/imagetools.py
@@ -27,7 +27,7 @@ def FetchTile(obKey, display_whole_image=False, z=None):
     '''
     imKey = obKey[:-1]
     # Could transform object coords here
-    if p.process_3D:
+    if p.process_3D and not display_whole_image:
         pos = list(db.GetObjectCoords(obKey))
         if len(pos)<3:
             message = ('Too few coordinates for object key %s. This may '
@@ -37,6 +37,8 @@ def FetchTile(obKey, display_whole_image=False, z=None):
             return None
         else:
             z=pos[2]
+    elif p.process_3D and display_whole_image:
+        z="mid"
 
     imgs = FetchImage(imKey, z=z)
     if imgs is None:

--- a/cpa/imagetools.py
+++ b/cpa/imagetools.py
@@ -81,9 +81,9 @@ def FetchImage(imKey, z=None):
             del cache[cachedkeys.pop(0)]
         return cache[imKey]
 
-def ShowImage(imKey, chMap, parent=None, brightness=1.0, scale=1.0, contrast=None):
+def ShowImage(imKey, chMap, parent=None, brightness=1.0, scale=1.0, contrast=None, z=None):
     from .imageviewer import ImageViewer
-    imgs = FetchImage(imKey)
+    imgs = FetchImage(imKey, z=z)
     if imgs is None:
         return
     frame = ImageViewer(imgs=imgs, chMap=chMap, img_key=imKey,

--- a/cpa/imagetools.py
+++ b/cpa/imagetools.py
@@ -27,18 +27,22 @@ def FetchTile(obKey, display_whole_image=False, z=None):
     '''
     imKey = obKey[:-1]
     # Could transform object coords here
+    pos = list(db.GetObjectCoords(obKey))
+    if(len(pos)==3):
+        z=pos[2]
+    print('z is',z)
     imgs = FetchImage(imKey, z=z)
     if imgs is None:
         # Loading failed, return gracefully.
         return
-    
+
     size = (int(p.image_size),int(p.image_size))
     if display_whole_image:
         return imgs
 
     else:
         size = (int(p.image_tile_size), int(p.image_tile_size))
-        pos = list(db.GetObjectCoords(obKey))
+        #pos = list(db.GetObjectCoords(obKey))
         if None in pos:
             message = ('Failed to load coordinates for object key %s. This may '
                        'indicate a problem with your per-object table.\n'
@@ -94,7 +98,7 @@ def Crop(imgdata, xxx_todo_changeme, xxx_todo_changeme1):
     Area outside of the image is filled with the color specified.
     '''
     (w,h) = xxx_todo_changeme
-    (x,y) = xxx_todo_changeme1
+    (x,y, *other) = xxx_todo_changeme1 #this ignores z if present
     im_width = imgdata.shape[1]
     im_height = imgdata.shape[0]
 

--- a/cpa/imagetools.py
+++ b/cpa/imagetools.py
@@ -27,10 +27,17 @@ def FetchTile(obKey, display_whole_image=False, z=None):
     '''
     imKey = obKey[:-1]
     # Could transform object coords here
-    pos = list(db.GetObjectCoords(obKey))
-    if(len(pos)==3):
-        z=pos[2]
-    #print('z is',z)
+    if p.process_3D:
+        pos = list(db.GetObjectCoords(obKey))
+        if len(pos)<3:
+            message = ('Too few coordinates for object key %s. This may '
+                       'indicate a problem with your per-object table or properties file. \n')
+            wx.MessageBox(message, 'Error')
+            logging.error(message)
+            return None
+        else:
+            z=pos[2]
+
     imgs = FetchImage(imKey, z=z)
     if imgs is None:
         # Loading failed, return gracefully.
@@ -42,7 +49,8 @@ def FetchTile(obKey, display_whole_image=False, z=None):
 
     else:
         size = (int(p.image_tile_size), int(p.image_tile_size))
-        #pos = list(db.GetObjectCoords(obKey))
+        if not p.process_3D: 
+            pos = list(db.GetObjectCoords(obKey))
         if None in pos:
             message = ('Failed to load coordinates for object key %s. This may '
                        'indicate a problem with your per-object table.\n'

--- a/cpa/imageviewer.py
+++ b/cpa/imageviewer.py
@@ -6,7 +6,7 @@
 #image_file_cols = Image_FileName_OutlinedAxons,Image_FileName_SomaOutlines,Image_FileName_SkelDendrites,Image_FileName_SkelAxons,Image_FileName_ColorImage,Image_FileName_OrigD,Image_FileName_OrigA,Image_FileName_OrigN,Image_FileName_OutlinedDendrites
 #image_names = OutlinedAxons,SomaOutlines,SkelDendrites,SkelAxons,ColorImage,OrigD,OrigA,OrigN,OutlinedDendrites
 #channels_per_image  = 3,3,1,1,3,1,1,1,3
-#image_channel_colors = none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, 
+#image_channel_colors = none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none,
 #########################
 
 import cpa.helpmenu
@@ -61,7 +61,7 @@ def rescale_display_coord_to_image(x, y):
 
 class ImageViewerPanel(ImagePanel):
     '''
-    ImagePanel with selection and object class labels. 
+    ImagePanel with selection and object class labels.
     '''
     def __init__(self, imgs, chMap, img_key, parent, scale=1.0, brightness=1.0, contrast=None):
         super(ImageViewerPanel, self).__init__(imgs, chMap, parent, scale, brightness, contrast=contrast, display_whole_image=True)
@@ -154,7 +154,7 @@ class ImageViewerPanel(ImagePanel):
 
         self.classVisible = {}
         for className in classes.keys():
-            self.classVisible[className] = True 
+            self.classVisible[className] = True
         self.Refresh()
 
     def ToggleObjectNumbers(self):
@@ -177,15 +177,15 @@ class ImageViewerPanel(ImagePanel):
 
 class ImageViewer(wx.Frame):
     '''
-    A frame that takes a list of np arrays representing image channels 
+    A frame that takes a list of np arrays representing image channels
     and merges and displays them as a single image.
     Menus are provided to change the RGB mapping of each channel passed in.
     Note: chMap is passed by reference by default, this means that the caller
        of ImageViewer can have it's own chMap (if any) updated by changes
        made in the viewer.  Otherwise pass in a copy.
     '''
-    def __init__(self, imgs=None, chMap=None, img_key=None, parent=None, title='Image Viewer', 
-                 classifier=None, brightness=1.0, scale=1.0, contrast=None, 
+    def __init__(self, imgs=None, chMap=None, img_key=None, parent=None, title='Image Viewer',
+                 classifier=None, brightness=1.0, scale=1.0, contrast=None,
                  classCoords=None):
         '''
         imgs  : [np.array(dtype=float32), ... ]
@@ -254,8 +254,8 @@ class ImageViewer(wx.Frame):
         self.toggleChMap = self.chMap[:]
         if self.imagePanel:
             self.imagePanel.Destroy()
-        self.imagePanel = ImageViewerPanel(imgs, self.chMap, self.img_key, 
-                                           self.sw, brightness=brightness, 
+        self.imagePanel = ImageViewerPanel(imgs, self.chMap, self.img_key,
+                                           self.sw, brightness=brightness,
                                            scale=scale, contrast=contrast)
         self.imagePanel.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)
         self.imagePanel.Bind(wx.EVT_SIZE, self.OnResizeImagePanel)
@@ -285,7 +285,7 @@ class ImageViewer(wx.Frame):
 
 
     #######################################
-    # CreateChannelMenus 
+    # CreateChannelMenus
     #######################################
     def CreateChannelMenus(self):
         ''' Create color-selection menus for each channel. '''
@@ -315,7 +315,7 @@ class ImageViewer(wx.Frame):
         startIndex = 0
 
         # Construct channel names, for RGB images, append a # to the end of
-        # each channel. 
+        # each channel.
         for i, chans in enumerate(p.channels_per_image):
             chans = int(chans)
             name = p.image_names[i]
@@ -339,34 +339,34 @@ class ImageViewer(wx.Frame):
                 channel_menu = wx.Menu()
                 for color in ['Red', 'Green', 'Blue', 'Cyan', 'Magenta', 'Yellow', 'Gray', 'None']:
                     id = wx.NewId()
-                    # Create a radio item that maps an id and a color. 
+                    # Create a radio item that maps an id and a color.
                     item = channel_menu.AppendRadioItem(id,color)
                     # Add a new chmapbyId object
                     self.chMapById[id] = (chIndex, color, item, channel_menu)
                     # If lowercase color matches what it was originally set to...
                     if color.lower() == setColor.lower():
-                        # Check off the item 
+                        # Check off the item
                         item.Check()
                     # Bind
                     self.Bind(wx.EVT_MENU, self.OnMapChannels, item)
                     # Add appropriate Ids to imMapById
-                    if ((int(p.channels_per_image[i]) == 1 and color == 'Gray') or 
-                        (int(p.channels_per_image[i]) > 1 and j == 0 and color == 'Red') or 
-                        (int(p.channels_per_image[i]) > 1 and j == 2 and color == 'Blue') or 
-                        (int(p.channels_per_image[i]) > 1 and j == 1 and color == 'Green')): 
+                    if ((int(p.channels_per_image[i]) == 1 and color == 'Gray') or
+                        (int(p.channels_per_image[i]) > 1 and j == 0 and color == 'Red') or
+                        (int(p.channels_per_image[i]) > 1 and j == 2 and color == 'Blue') or
+                        (int(p.channels_per_image[i]) > 1 and j == 1 and color == 'Green')):
                         channelIds = channelIds + [id]
-                # Add new menu item  
+                # Add new menu item
                 self.GetMenuBar().Append(channel_menu, channel)
                 chIndex+=1
             # New id for the image as a whole
             id = wx.NewId()
             item = self.imagesMenu.AppendRadioItem(id, p.image_names[i])
             #Effectively this code creates a data structure that stores relevant info with ID as a key
-            self.imMapById[id] = (int(p.channels_per_image[i]), item, startIndex, channelIds) 
-            # Binds the event menu to OnFetchImage (below) and item 
+            self.imMapById[id] = (int(p.channels_per_image[i]), item, startIndex, channelIds)
+            # Binds the event menu to OnFetchImage (below) and item
             self.Bind(wx.EVT_MENU, self.OnFetchImage, item)
             startIndex += int(p.channels_per_image[i])
-        # Add the "none" image and check it off. 
+        # Add the "none" image and check it off.
         id= wx.NewId()
         item = self.imagesMenu.AppendRadioItem(id, 'None')
         self.Bind(wx.EVT_MENU, self.OnFetchImage, item)
@@ -374,14 +374,14 @@ class ImageViewer(wx.Frame):
         # Add new "Images" menu bar item
         self.GetMenuBar().Append(self.imagesMenu, 'Images')
     #######################################
-    # /CreateChannelMenus 
+    # /CreateChannelMenus
     #######################################
 
 
 
     #######################################
     # OnFetchImage
-    # 
+    #
     # Allows user to display one image at a time.  If image is single channel,
     # displays the image as gray.  If image is multichannel, displays image as
     # RGB.
@@ -391,9 +391,9 @@ class ImageViewer(wx.Frame):
 
         # Set every channel to black and set all the toggle options to 'none'
         for ids in list(self.chMapById.keys()):
-            (chIndex, color, item, channel_menu) = self.chMapById[ids] 
+            (chIndex, color, item, channel_menu) = self.chMapById[ids]
             if (color.lower() == 'none'):
-                item.Check()		
+                item.Check()
         for ids in list(self.imMapById.keys()):
             (cpi, itm, si, channelIds) = self.imMapById[ids]
             if cpi == 3:
@@ -413,22 +413,22 @@ class ImageViewer(wx.Frame):
             (chanPerIm, item, startIndex, channelIds) = self.imMapById[evt.GetId()]
 
             if chanPerIm == 1:
-                # Set channel map and toggleChMap values. 
+                # Set channel map and toggleChMap values.
                 self.chMap[startIndex] = 'gray'
                 self.toggleChMap[startIndex] = 'gray'
 
                 # Toggle the option for the independent channel menu
-                (chIndex, color, item, channel_menu) = self.chMapById[channelIds[0]] 
+                (chIndex, color, item, channel_menu) = self.chMapById[channelIds[0]]
                 item.Check()
             else:
                 RGB = ['red', 'green', 'blue'] + ['none'] * chanPerIm
                 for i in range(chanPerIm):
                     # Set chMap and toggleChMap values
                     self.chMap[startIndex + i] = RGB[i]
-                    self.toggleChMap[startIndex + i] = RGB[i]                
+                    self.toggleChMap[startIndex + i] = RGB[i]
                     # Toggle the option in the independent channel menus
-                    (chIndex, color, item, channel_menu) = self.chMapById[channelIds[i]] 
-                    item.Check()                
+                    (chIndex, color, item, channel_menu) = self.chMapById[channelIds[i]]
+                    item.Check()
 
         self.MapChannels(self.chMap)
         #######################################
@@ -441,9 +441,9 @@ class ImageViewer(wx.Frame):
             if not self.cp:
                 self.cp = wx.CollapsiblePane(self, label='Show controls', style=wx.CP_DEFAULT_STYLE|wx.CP_NO_TLW_RESIZE)
                 self.SetBackgroundColour('white') # color for the background of panel
-                self.controls  = ImageControlPanel(self.cp.GetPane(), self.imagePanel, 
+                self.controls  = ImageControlPanel(self.cp.GetPane(), self.imagePanel,
                                                    brightness=self.imagePanel.brightness,
-                                                   scale=self.imagePanel.scale, 
+                                                   scale=self.imagePanel.scale,
                                                    contrast=self.imagePanel.contrast)
                 self.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self.OnPaneChanged, self.cp)
                 # self.cp.Collapse(collapse=False) # default open controls
@@ -463,7 +463,7 @@ class ImageViewer(wx.Frame):
             self.CreateChannelMenus()
 
             # Annoying: Need to bind 3 windows to KEY_DOWN in case focus changes.
-            self.Bind(wx.EVT_KEY_DOWN, self.HoldKey) 
+            self.Bind(wx.EVT_KEY_DOWN, self.HoldKey)
             self.sw.Bind(wx.EVT_KEY_DOWN, self.HoldKey)
             self.cp.Bind(wx.EVT_KEY_DOWN, self.HoldKey)
             self.imagePanel.Bind(wx.EVT_KEY_DOWN, self.HoldKey)
@@ -552,7 +552,7 @@ class ImageViewer(wx.Frame):
                 brightness = self.imagePanel.tmp_brightness
                 self.imagePanel.SetBrightness(brightness)
                 self.inspect_release = True # Tell the panel, F key is not pressed anymore, otherwise it is stuck in key down events.
-            elif len(self.chMap) > chIdx >= 0:   
+            elif len(self.chMap) > chIdx >= 0:
                 # ctrl+n where n is the nth channel
                 self.ToggleChannel(chIdx)
             else:
@@ -571,7 +571,7 @@ class ImageViewer(wx.Frame):
         if self.chMap[chIdx] == 'None':
             for (idx, color, item, menu) in list(self.chMapById.values()):
                 if idx == chIdx and color.lower() == self.toggleChMap[chIdx].lower():
-                    item.Check()   
+                    item.Check()
             self.chMap[chIdx] = self.toggleChMap[chIdx]
             self.MapChannels(self.chMap)
         else:
@@ -594,7 +594,7 @@ class ImageViewer(wx.Frame):
         self.imagePanel.DeselectAll()
 
     def SelectObject(self, obkey):
-        coord = db.GetObjectCoords(obkey)
+        coord = db.GetObjectCoords(obkey)[0:2] #x and y only
         if p.rescale_object_coords:
             coord = rescale_image_coord_to_display(coord[0], coord[1])
         self.selection += [coord]
@@ -628,7 +628,7 @@ class ImageViewer(wx.Frame):
                     self.selection.remove(obKey)
 
             # select the object
-            (x,y) = db.GetObjectCoords(obKey)            
+            (x,y,*other) = db.GetObjectCoords(obKey)
             if p.rescale_object_coords:
                 x, y = rescale_image_coord_to_display(x, y)
             self.imagePanel.TogglePointSelection((x,y))
@@ -692,7 +692,7 @@ class ImageViewer(wx.Frame):
             errdlg = wx.MessageDialog(self, 'There is no image with that key.', "Couldn't find image", wx.OK|wx.ICON_EXCLAMATION)
             errdlg.ShowModal()
             self.Destroy()
-        else:            
+        else:
             # load the image
             self.img_key = imkey
             self.SetImage(imagetools.FetchImage(imkey), p.image_channel_colors)
@@ -702,7 +702,7 @@ class ImageViewer(wx.Frame):
         import os
         saveDialog = wx.FileDialog(self, message="Save as:",
                                    defaultDir=self.defaultPath, defaultFile=self.defaultFile,
-                                   wildcard='PNG file (*.png)|*.png|JPG file (*.jpg, *.jpeg)|*.jpg', 
+                                   wildcard='PNG file (*.png)|*.png|JPG file (*.jpg, *.jpeg)|*.jpg',
                                    style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
         if saveDialog.ShowModal()==wx.ID_OK:
             filename = str(saveDialog.GetPath())
@@ -780,7 +780,7 @@ if __name__ == "__main__":
               ]
 
     pixels = []
-    for channel in p.image_channel_colors:        
+    for channel in p.image_channel_colors:
         pixels += [imagetools.tile_images(images)]
 
     f = ImageViewer(pixels)
@@ -791,11 +791,11 @@ if __name__ == "__main__":
 ##        logging.error('ImageViewer requires a properties file.  Exiting.')
 ##        wx.GetApp().Exit()
 ##        raise Exception('ImageViewer requires a properties file.  Exiting.')
-##    
+##
 ##    db = DBConnect()
 ##    dm = DataModel()
 ##    ir = ImageReader()
-##    
+##
 ##    obKey = dm.GetRandomObject()
 ##    imagetools.ShowImage(obKey[:-1], p.image_channel_colors, None)
 #    filenames = db.GetFullChannelPathsForImage(obKey[:-1])

--- a/cpa/properties.py
+++ b/cpa/properties.py
@@ -67,7 +67,8 @@ string_vars = ['db_type',
                'negative_control', # For DMSO normalization, but optional
                'class_names',
                'force_bioformats',
-               'use_legacy_fetcher'
+               'use_legacy_fetcher',
+               'process_3D'
                ]
 
 list_vars = ['image_path_cols', 'image_channel_paths',
@@ -132,7 +133,8 @@ optional_vars = ['db_port',
                  'negative_control',
                  'class_names',
                  'force_bioformats',
-                 'use_legacy_fetcher'
+                 'use_legacy_fetcher',
+                 'process_3D'
                  ]
 
 # map deprecated fields to new fields
@@ -694,6 +696,16 @@ class Properties(metaclass=Singleton):
             self.use_legacy_fetcher = False
         else:
             self.use_legacy_fetcher = False
+
+        if self.field_defined('process_3D') and self.process_3D.lower() in ['true', 'yes', 'on', 't', 'y']:
+            self.process_3D = True
+        elif self.field_defined('process_3D') and self.process_3D.lower() in ['false', 'no', 'off', 'f', 'n']:
+            self.process_3D = False
+        elif self.field_defined('process_3D'):
+            logging.warn(f'[Properties] WARNING (process_3D): Field was invalid ({self.process_3D}), using default of "False".')
+            self.process_3D = False
+        else:
+            self.process_3D = False
 
         if self.use_larger_image_scale in [True, False]:
             pass

--- a/cpa/properties.py
+++ b/cpa/properties.py
@@ -24,26 +24,27 @@ supported_plate_types = {'6'    : [2, 3],
                          '5600' : [40, 140],
                          }
 
-string_vars = ['db_type', 
-               'db_port', 
-               'db_host', 
-               'db_name', 
-               'db_user', 
+string_vars = ['db_type',
+               'db_port',
+               'db_host',
+               'db_name',
+               'db_user',
                'db_passwd',
                'db_password',
-               'image_table', 
+               'image_table',
                'object_table',
-               'image_csv_file', 
+               'image_csv_file',
                'object_csv_file',
-               'table_id', 
-               'image_id', 
-               'object_id', 
-               'plate_id', 
+               'table_id',
+               'image_id',
+               'object_id',
+               'plate_id',
                'well_id',
-               'cell_x_loc', 
+               'cell_x_loc',
                'cell_y_loc',
+               'cell_z_loc',
                'image_url_prepend',
-               'image_tile_size', 
+               'image_tile_size',
                'image_buffer_size',
                'tile_buffer_size',
                'area_scoring_column',
@@ -53,7 +54,7 @@ string_vars = ['db_type',
                'check_tables',
                'db_sql_file',
                'db_sqlite_file',
-               'use_larger_image_scale', 
+               'use_larger_image_scale',
                'rescale_object_coords',
                'well_format',
                'link_tables_table',
@@ -69,52 +70,53 @@ string_vars = ['db_type',
                'use_legacy_fetcher'
                ]
 
-list_vars = ['image_path_cols', 'image_channel_paths', 
-             'image_file_cols', 'image_channel_files', 
-             'image_names', 'image_channel_names', 
-             'image_channel_colors', 
-             'channels_per_image', 
-             'image_channel_blend_modes', 
+list_vars = ['image_path_cols', 'image_channel_paths',
+             'image_file_cols', 'image_channel_files',
+             'image_names', 'image_channel_names',
+             'image_channel_colors',
+             'channels_per_image',
+             'image_channel_blend_modes',
              'object_name',
-             'classifier_ignore_substrings', 
+             'classifier_ignore_substrings',
              'classifier_ignore_columns',
              'image_thumbnail_cols',
              'plate_shape',]
 
 dict_vars = ['gates']
 
-optional_vars = ['db_port', 
-                 'db_host', 
-                 'db_name', 
-                 'db_user', 
+optional_vars = ['db_port',
+                 'db_host',
+                 'db_name',
+                 'db_user',
                  'db_passwd',
                  'db_password',
-                 'table_id', 
-                 'image_url_prepend', 
+                 'table_id',
+                 'image_url_prepend',
                  'image_csv_file',
-                 'image_channel_names', 'image_names', 
+                 'image_channel_names', 'image_names',
                  'image_channel_colors',
-                 'channels_per_image', 
+                 'channels_per_image',
                  'image_channel_blend_modes',
-                 'object_csv_file', 
-                 'area_scoring_column', 
+                 'object_csv_file',
+                 'area_scoring_column',
                  'training_set',
                  'class_table',
-                 'image_buffer_size', 
+                 'image_buffer_size',
                  'tile_buffer_size',
-                 'plate_id', 
-                 'well_id', 
+                 'plate_id',
+                 'well_id',
                  'plate_type',
                  'classifier_ignore_substrings', 'classifier_ignore_columns',
                  'object_name',
                  'check_tables',
                  'db_sql_file',
                  'db_sqlite_file',
-                 'object_table', 
+                 'object_table',
                  'object_id',
-                 'cell_x_loc', 
+                 'cell_x_loc',
                  'cell_y_loc',
-                 'use_larger_image_scale', 
+                 'cell_z_loc',
+                 'use_larger_image_scale',
                  'rescale_object_coords',
                  'image_thumbnail_cols',
                  'well_format',
@@ -141,7 +143,7 @@ field_mappings = {'classifier_ignore_substrings': 'classifier_ignore_columns',
                   'db_password': 'db_passwd',
                   }
 
-required_vars = list(set(list_vars + string_vars) - set(optional_vars) 
+required_vars = list(set(list_vars + string_vars) - set(optional_vars)
                      - set(field_mappings.keys()))
 
 valid_vars = set(list_vars + string_vars + dict_vars)
@@ -151,41 +153,41 @@ class Properties(metaclass=Singleton):
     Loads and stores properties files.
     '''
     def __init__(self):
-        super(Properties, self).__init__()        
+        super(Properties, self).__init__()
         self._initialized = False
-        
+
     @property
     def _filters_ordered(self):
         return sorted(self._filters.keys())
-    
+
     @property
     def _groups_ordered(self):
         return sorted(self._groups.keys())
-    
+
     @property
     def gates_ordered(self):
         return sorted(self.gates.keys())
-    
+
     def __str__(self):
         s=''
         for k, v in sorted(self.__dict__.items()):
             if not str(k).startswith('_'):
                 s += k+" = "+str(v)+"\n"
         return s
-        
+
     def __getattr__(self, field):
         # The name may not be loaded for optional fields.
         if (field not in self.__dict__) and (field in valid_vars):
             return None
         else:
             return self.__dict__[field]
-        
+
     def __setattr__(self, field, val):
         self.__dict__[field] = val
 
     def show_load_dialog(self):
         '''
-        Note: this is only used for loading properties files. To load Columbus 
+        Note: this is only used for loading properties files. To load Columbus
         output files, use guiutils.show_load_dialog
         '''
         import wx
@@ -199,7 +201,7 @@ class Properties(metaclass=Singleton):
             return True
         else:
             return False
-        
+
     def parse_list_value(self, list_str):
         '''parses a list property given as a string and returns it as a list
         '''
@@ -209,11 +211,11 @@ class Properties(metaclass=Singleton):
         if list_str.strip().startswith("`") and list_str.strip().endswith("`"):
             return [v.strip() for v in list_str.strip()[1:-1].split("`,`") if v.strip() != '']
         return [v.strip() for v in list_str.split(',') if v.strip() != '']
-        
+
     def load_file(self, filename):
         ''' Loads variables in from a properties file. '''
         from .sqltools import Gate, Filter, OldFilter
-        
+
         self.clear()
         self._filename        = filename
         self._groups          = {}
@@ -237,13 +239,13 @@ class Properties(metaclass=Singleton):
                     raise Exception('[Properties] ERROR: Could not parse line #%d\n'
                                     '\t"%s"\n'
                                     'Did you accidentally load your training set instead of your properties file?'%(idx + 1, line))
-                
+
                 if name in string_vars:
                     self.__dict__[name] = val or None
-                
+
                 elif name in list_vars:
                     self.__dict__[name] = self.parse_list_value(val) or None
-                    
+
                 elif name.startswith('group_SQL_'):
                     group_name = name[10:]
                     if group_name == '':
@@ -258,7 +260,7 @@ class Properties(metaclass=Singleton):
                         logging.warn('[Properties] WARNING (%s): Undefined group'%(name))
                         continue
                     self._groups[group_name] = val
-                    
+
                 elif name.startswith('filter_SQL_'):
                     # Load old-style SQL filters:
                     filter_name = name[11:]
@@ -276,11 +278,11 @@ class Properties(metaclass=Singleton):
                         logging.warn('[Properties] WARNING (%s): Undefined filter'%(name))
                         continue
                     self._filters[filter_name] = OldFilter(val)
-                
+
                 elif name == 'groups':
                     logging.warn('[Properties] INFO (%s): This field is no longer necessary in the properties file.\n'
                               'Only the group_SQL_XXX and filter_SQL_XXX fields are needed when defining groups and filters.'%(name))
-                    
+
                 elif name == 'filters':
                     # Load new-style filters
                     if val.strip() == '':
@@ -292,7 +294,7 @@ class Properties(metaclass=Singleton):
                     for k, v in list(d.items()):
                         self._filters[k] = Filter.decode(v)
                     del d
-                        
+
                 elif name == 'gates':
                     d = eval(val)
                     if type(d) != dict:
@@ -300,12 +302,12 @@ class Properties(metaclass=Singleton):
                     for k, v in list(d.items()):
                         self.gates[k] = Gate.decode(v)
                     del d
-                    
+
                 else:
                     logging.warn('[Properties] INFO: Unrecognized field "%s" in properties file'%(name))
-                
+
         f.close()
-        
+
         #if classification_type is defined
         if self.field_defined('classification_type') and self.classification_type.lower() in ['image']:
             self.classification_type = 'image'
@@ -318,9 +320,11 @@ class Properties(metaclass=Singleton):
             self.object_id = 'ObjectNumber'
             self.cell_x_loc = 'Image_x_loc'
             self.cell_y_loc = 'Image_y_loc'
+            self.cell_z_loc = 'Image_z_loc'
+
             self.object_name = ['image','images']
 
-            # image_width and image_height refer to the full image width and height while 
+            # image_width and image_height refer to the full image width and height while
             # image_tile_size refers to the size of tiles for classification
             # NB: if image_width and image_height are defined, they override image_tile_size
             if self.field_defined('image_width') and self.field_defined('image_height'):
@@ -362,7 +366,7 @@ class Properties(metaclass=Singleton):
 
         if not os.path.exists(properties_filename):
             self.save_file(properties_filename)
-        
+
     def save_file(self, filename):
         '''
         Saves the file.
@@ -371,13 +375,13 @@ class Properties(metaclass=Singleton):
         from . import sqltools
         fd = open(filename, 'w')
         self._filename = filename
-        
+
         # Write revision first
         #import util.version
         #__version__ = util.version.
         #fd.write('# CellProfiler Analyst revision: %s\n'%(__version__))
-        
-        fields_to_write = sorted([k for k, v in list(self.__dict__.items()) 
+
+        fields_to_write = sorted([k for k, v in list(self.__dict__.items())
                                   if not k.startswith('_') and v is not None])
 
         for field in fields_to_write:
@@ -391,13 +395,13 @@ class Properties(metaclass=Singleton):
                 fd.write('%s  =  %s\n'%(field, val))
 
         # Write new filters
-        encoded = repr( dict([ (k, f.encode()) 
-                              for k, f in list(self._filters.items()) 
+        encoded = repr( dict([ (k, f.encode())
+                              for k, f in list(self._filters.items())
                               if isinstance(f,sqltools.Filter) and f.is_not_empty() ])
                         )
         fd.write('# These filters were created while using CPAnalyst. Do not edit.\n')
         fd.write('filters  =  %s\n'%(encoded))
-                
+
         # write old groups and filters back as they were
         for line in StringIO(self._textfile):
             if not (line.strip().startswith('#') or line.strip()==''):
@@ -411,8 +415,8 @@ class Properties(metaclass=Singleton):
                 if field.startswith('group_SQL_'):
                     fd.write(line)
         fd.close()
-        
-        
+
+
 ##        # Write whole file out replacing any changed values
 ##        for line in StringIO(self._textfile):
 ##            if line.strip().startswith('#') or line.strip()=='':
@@ -438,7 +442,7 @@ class Properties(metaclass=Singleton):
 ##                    else:
 ##                        fd.write('%s  =  %s\n'%(name, val))
 ##                fields_to_write.remove(name)
-##        
+##
 ##        fd.write('\n')
 ##        # Write out fields that weren't present in the file
 ##        for field in fields_to_write:
@@ -449,9 +453,9 @@ class Properties(metaclass=Singleton):
 ##                fd.write(repr(dict(zip(val.keys(), [g.encode() for g in val.values()]))))
 ##            else:
 ##                fd.write('%s  =  %s\n'%(field, val))
-##        
+##
 ##        fd.close()
-        
+
     def clear(self):
         from .utils import ObservableDict
         # only clear known variables
@@ -460,14 +464,14 @@ class Properties(metaclass=Singleton):
         self._groups      = {}
         self._filters     = ObservableDict()
         self._initialized = False
-        
+
     def is_initialized(self):
         return self._initialized
 
     def field_defined(self, name):
         # field name exists and has a non-empty value.
         return self.__dict__.get(name, None) not in ['', None]
-    
+
     def backwards_compatiblize(self):
         ''' Update any old fields to new ones in field_mappings.
         '''
@@ -489,12 +493,12 @@ class Properties(metaclass=Singleton):
         '''
         # update old fields
         self.backwards_compatiblize()
-        
+
         # check that all required fields are defined
         required_vars_all = required_vars
         for name in required_vars_all:
             assert self.field_defined(name), '[Properties] ERROR (%s): Field is missing or empty.'%(name)
-        
+
         assert self.db_type.lower() in ['mysql', 'sqlite'], '[Properties] ERROR (db_type): Value must be either "mysql" or "sqlite".'
 
         # BELOW: Check sometimes-optional fields, and print warnings etc
@@ -502,21 +506,21 @@ class Properties(metaclass=Singleton):
             for field in ['db_port', 'db_host', 'db_name', 'db_user', 'db_passwd',]:
                 if self.field_defined(field):
                     logging.info('[Properties] DEBUG (%s): Field not required with db_type=sqlite.'%(field))
-            
+
             assert any([self.field_defined(field) for field in ['image_csv_file','object_csv_file','db_sql_file','db_sqlite_file']]), \
                     '[Properties] ERROR: When using db_type=sqlite, you must also supply the fields "image_csv_file" and "object_csv_file" OR "db_sql_file" OR "db_sqlite_file". See the README.'
-            
+
             if self.field_defined('db_sqlite_file'):
                 if not os.path.isabs(self.db_sqlite_file):
                     # Make relative paths relative to the props file location
                     # TODO: This sholdn't be permanent
-                    self.db_sqlite_file = os.path.join(os.path.dirname(self._filename), self.db_sqlite_file)                
+                    self.db_sqlite_file = os.path.join(os.path.dirname(self._filename), self.db_sqlite_file)
                 try:
                     f = open(self.db_sqlite_file, 'r')
                     f.close()
                 except:
                     raise Exception('[Properties] ERROR (%s): SQLite database could not be found at "%s".'%('db_sqlite_file', self.db_sqlite_file))
-            
+
             if self.field_defined('db_sql_file'):
                 if not os.path.isabs(self.db_sql_file):
                     # Make relative paths relative to the props file location
@@ -527,10 +531,10 @@ class Properties(metaclass=Singleton):
                     f.close()
                 except:
                     raise Exception('[Properties] ERROR (%s): File "%s" could not be found.'%('db_sql_file', self.db_sql_file))
-                
+
                 for field in ['image_csv_file','object_csv_file']:
                     assert not self.field_defined(field), '[Properties] ERROR (%s, db_sql_file): Both of these fields cannot be used at the same time.'%(field)
-            else:        
+            else:
                 for field in ['image_csv_file','object_csv_file']:
                     if self.field_defined(field):
                         if not os.path.isabs(self.__dict__[field]):
@@ -543,7 +547,7 @@ class Properties(metaclass=Singleton):
                             f.close()
                         except:
                             raise Exception('[Properties] ERROR (%s): File "%s" could not be found.'%(field, self.__dict__[field]))
-            
+
         if self.db_type.lower()=='mysql':
             for field in ['db_host', 'db_name', 'db_user',]:
                 assert self.field_defined(field), '[Properties] ERROR (%s): Field is required with db_type=mysql.'%(field)
@@ -553,14 +557,14 @@ class Properties(metaclass=Singleton):
             for field in ['image_csv_file','object_csv_file']:
                 if self.field_defined(field):
                     logging.warn('[Properties] INFO (%s): Field not required with db_type=mysql.'%(field))
-        
+
         if self.field_defined('area_scoring_column'):
             logging.warn('[Properties]: Area scoring will be used.')
-                
+
         if not self.field_defined('image_channel_colors'):
             logging.warn('[Properties] INFO (image_channel_colors): No value(s) specified. CPA will use a generic channel-color mapping.')
             self.image_channel_colors = ['red', 'green', 'blue']+['none' for x in range(97)]
-        
+
         if not self.field_defined('channels_per_image'):
             logging.warn('[Properties] INFO (channels_per_image): No value(s) specified. CPA will assume 1 channel per image.')
             self.channels_per_image = ['1' for i in range(len(self.image_file_cols))]
@@ -582,28 +586,28 @@ class Properties(metaclass=Singleton):
 
         assert len(self.image_file_cols) == len(self.image_path_cols), \
                '[Properties] ERROR: image_file_cols and image_path_cols must have an equal number of values.'
-        
+
         assert len(self.image_file_cols) == len(self.channels_per_image), \
                '[Properties] ERROR: channels_per_image must have the same number of values as image_file_cols  and image_path_cols.'
 
         assert len(self.image_file_cols) == len(self.image_names), \
                '[Properties] ERROR: image_names must have the same number of values as image_file_cols  and image_path_cols.'
-                    
+
         if self.field_defined('image_channel_blend_modes'):
             for mode in self.image_channel_blend_modes:
                 assert mode in ['add', 'subtract', 'solid'], '[Properties] ERROR (image_channel_blend_modes): Blend modes must list of modes (1 for each image channel). Valid modes are add, subtract and solid.'
-            
+
         if not self.field_defined('classifier_ignore_columns'):
             logging.warn('[Properties] INFORNING (classifier_ignore_columns): No value(s) specified. Classifier will use ALL NUMERIC per_object columns when training.')
-        
+
         if not self.field_defined('image_buffer_size'):
             logging.info('[Properties]: Using default image_buffer_size=1')
             self.image_buffer_size = '1'
-            
+
         if not self.field_defined('tile_buffer_size'):
             logging.info('[Properties]: Using default tile_buffer_size=1')
             self.tile_buffer_size = '1'
-            
+
         if not self.field_defined('object_name'):
             logging.warn('[Properties] WARNING (object_name): No object name specified, will use default: "object_name=cell,cells"')
             self.object_name = ['cell', 'cells']
@@ -622,18 +626,18 @@ class Properties(metaclass=Singleton):
             except:
                 logging.warn('[Properties] WARNING (training_set): Training set at "%s" could not be found.'%(self.training_set))
             logging.warn('[Properties]: Training set found at "%s"'%(self.training_set))
-        
+
         if self.field_defined('class_table'):
             assert self.class_table != self.image_table, '[Properties] ERROR (class_table): class_table cannot be the same as image_table!'
             assert self.class_table != self.object_table, '[Properties] ERROR (class_table): class_table cannot be the same as object_table!'
             logging.info('[Properties]: Per-Object classes will be written to table "%s"'%(self.class_table))
-            
+
         if not self.field_defined('plate_id'):
             logging.warn('[Properties] INFO (plate_id): Field is required for plate map viewer.')
-                                    
+
         if not self.field_defined('well_id'):
             logging.warn('[Properties] INFO (well_id): Field is required for plate map viewer.')
-        
+
         #
         # plate_shape
         # This field can be set directly, otherwise it is set indirectly by the plate_type field
@@ -648,7 +652,7 @@ class Properties(metaclass=Singleton):
             except:
                 raise Exception('[Properties] ERROR: invalid value (%s) for plate_shape. Expected: rows, cols'
                                 %(self.__dict__['plate_shape']))
-            
+
         #
         # plate_type
         # This field is used to set the plate_shape field indirectly
@@ -700,7 +704,7 @@ class Properties(metaclass=Singleton):
         else:
             logging.warn('[Properties] WARNING (use_larger_image_scale): Field value "%s" is invalid. Replacing with "false".'%(self.use_larger_image_scale))
             self.use_larger_image_scale = False
-            
+
         if self.rescale_object_coords in [True, False]:
             pass
         elif not self.field_defined('rescale_object_coords') or self.rescale_object_coords.lower() in ['false', 'no', 'off', 'f', 'n']:
@@ -710,32 +714,32 @@ class Properties(metaclass=Singleton):
         else:
             logging.warn('[Properties] WARNING (rescale_object_coords): Field value "%s" is invalid. Replacing with "false".'%(self.rescale_object_coords))
             self.rescale_object_coords = False
-            
+
         if not self.field_defined('well_format'):
             self.well_format = 'A01'
             logging.info('[Properties] WARNING (well_format): Field was not defined, using default format of "A01".')
-            
+
         if not self.field_defined('link_tables_table'):
             self.link_tables_table = '_link_tables_%s_%s_'%(self.image_table, (self.object_table or ''))
             if len(self.link_tables_table) >= 64:
                 from hashlib import md5
                 self.link_tables_table = '_link_tables_%s'%(md5((self.image_table+(self.object_table or '')).encode()).hexdigest())
-            
+
         if not self.field_defined('link_columns_table'):
             self.link_columns_table = '_link_columns_%s_%s_'%(self.image_table, (self.object_table or ''))
             if len(self.link_columns_table) >= 64:
                 from hashlib import md5
                 self.link_columns_table = '_link_columns_%s'%(md5((self.image_table+(self.object_table or '')).encode()).hexdigest())
-            
+
         if not self.field_defined('gates'):
             from .utils import ObservableDict
             self.gates = ObservableDict()
-        
+
 
 if __name__ == "__main__":
     import sys
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-    
+
     p = Properties()
     if len(sys.argv) >= 2:
         filename = sys.argv[1]
@@ -743,5 +747,5 @@ if __name__ == "__main__":
         filename = '/Users/afraser/cpa_example/example.properties'
 
     p.load_file(filename)
-    
+
     print(p)

--- a/cpa/sortbin.py
+++ b/cpa/sortbin.py
@@ -28,23 +28,23 @@ class CellMontageFrame(wx.Frame):
         self.sb = SortBin(self)
         self.cp = wx.CollapsiblePane(self, label='Show controls', style=wx.CP_DEFAULT_STYLE|wx.CP_NO_TLW_RESIZE)
         self.icp = ImageControlPanel(self.cp.GetPane(), self)
-        
+
         self.Sizer = wx.BoxSizer(wx.VERTICAL)
         self.Sizer.Add(self.sb, 1, wx.EXPAND)
         self.Sizer.Add(self.cp, 0, wx.EXPAND)
-        
+
         self.cp.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self._on_control_pane_change)
-        
+
     def _on_control_pane_change(self, evt=None):
         self.Layout()
         if self.cp.IsExpanded():
             self.cp.SetLabel('Hide controls')
         else:
             self.cp.SetLabel('Show controls')
-        
+
     def add_objects(self, obkeys):
         self.sb.AddObjects(obkeys)
-        
+
     #
     # required by ImageControlPanel
     #
@@ -83,7 +83,7 @@ class SortBinDropTarget(wx.DropTarget):
         self.data = wx.CustomDataObject("application.cpa.ObjectKey")
         self.SetDataObject(self.data)
         self.bin = bin
-        
+
     def OnData(self, x, y, dragres):
         if not self.GetData():
             return wx.DragNone
@@ -198,7 +198,7 @@ class SortBin(wx.ScrolledWindow):
                 else:
                     imViewer = imagetools.ShowImage(key[:-1], self.chMap[:], parent=self)
 
-                imViewer.imagePanel.SelectPoint(db.GetObjectCoords(key))
+                imViewer.imagePanel.SelectPoint(db.GetObjectCoords(key)[0:2])
         elif choice == 1:
             self.SelectAll()
         elif choice == 2:
@@ -423,7 +423,7 @@ class SortBin(wx.ScrolledWindow):
     def OnTileUpdated(self, evt):
         ''' When the tile loader returns the cropped image update the tile. '''
         self.UpdateTile(evt.data)
-            
+
     def UpdateTile(self, obKey):
         ''' Called when image data is available for a specific tile. '''
         for t in self.tiles:
@@ -434,7 +434,7 @@ class SortBin(wx.ScrolledWindow):
             self.UpdateSizer()
 
     def UpdateSizer(self):
-        return self.SetVirtualSize(self.sizer.CalcMin())        
+        return self.SetVirtualSize(self.sizer.CalcMin())
 
     def UpdateQuantity(self):
         '''
@@ -457,11 +457,11 @@ class SortBin(wx.ScrolledWindow):
 
 if __name__ == '__main__':
     app = wx.App()
- 
-    p.show_load_dialog()    
+
+    p.show_load_dialog()
     from . import datamodel
     dm = datamodel.DataModel()
-    
+
     f = wx.Frame(None)
     sb = SortBin(f)
     f.Show()

--- a/cpa/sortbin.py
+++ b/cpa/sortbin.py
@@ -243,7 +243,7 @@ class SortBin(wx.ScrolledWindow):
             source.UpdateQuantity()
         else:
             imgSet = self.tile_collection.GetTiles(obKeys, (self.classifier or self), priority,
-                                                   display_whole_image=display_whole_image)
+                                                   display_whole_image=display_whole_image, processStack=p.process_3D)
             for i, obKey, imgs in zip(list(range(len(obKeys))), obKeys, imgSet):
                 if self.classifier:
                     newTile = ImageTile(self, obKey, imgs, chMap, False,

--- a/cpa/tests/testdbconnect.py
+++ b/cpa/tests/testdbconnect.py
@@ -154,6 +154,7 @@ class TestDBConnect(unittest.TestCase):
         self.setup_mysql()
         xy = self.db.GetObjectCoords((1,1))
         assert xy==(11.4818, 305.06400000000002)
+       
         self.setup_sqlite()
         xy = self.db.GetObjectCoords((0,1,1))
         assert xy==(11.4818, 305.06400000000002)

--- a/cpa/tests/testdbconnect.py
+++ b/cpa/tests/testdbconnect.py
@@ -17,65 +17,65 @@ class TestDBConnect(unittest.TestCase):
         self.db = DBConnect()
         self.db.Disconnect()
         self.p.LoadFile('../../CPAnalyst_test_data/nirht_local.properties')
-        
+
     def setup_sqlite2(self):
         self.p  = Properties()
         self.db = DBConnect()
         self.db.Disconnect()
         self.p.LoadFile('../../CPAnalyst_test_data/export_to_db_test.properties')
-        
-        
+
+
     #
     # Test module-level functions
     #
-       
+
     def test_clean_up_colnames(self):
         self.setup_mysql()
-    
+
     def test_well_key_columns(self):
         self.setup_mysql()
         assert well_key_columns() == ('plate', 'well')
         self.setup_sqlite()
         assert well_key_columns() == tuple()
-        
+
     def test_image_key_columns(self):
         self.setup_mysql()
         assert image_key_columns() == ('ImageNumber',)
         self.setup_sqlite()
         assert image_key_columns() == ('TableNumber','ImageNumber')
-    
+
     def test_object_key_columns(self):
         self.setup_mysql()
         assert object_key_columns() == ('ImageNumber','ObjectNumber')
         self.setup_sqlite()
         assert object_key_columns() == ('TableNumber', 'ImageNumber','ObjectNumber')
-    
+
     def test_GetWhereClauseForObjects(self):
         self.setup_mysql()
         assert GetWhereClauseForObjects([(1,1)]) == '(ImageNumber=1 AND ObjectNumber=1)'
         assert GetWhereClauseForObjects([(1,1), (2,1)]) == '(ImageNumber=1 AND ObjectNumber=1 OR ImageNumber=2 AND ObjectNumber=1)'
         self.setup_sqlite()
         assert GetWhereClauseForObjects([(0,1,1), (0,2,1)]) == '(TableNumber=0 AND ImageNumber=1 AND ObjectNumber=1 OR TableNumber=0 AND ImageNumber=2 AND ObjectNumber=1)'
-        
+
     def test_GetWhereClauseForImages(self):
         self.setup_mysql()
         assert GetWhereClauseForImages([(1,)]) == 'ImageNumber IN (1)'
         assert GetWhereClauseForImages([(1,), (2,)]) == 'ImageNumber IN (1,2)'
         self.setup_sqlite()
         assert GetWhereClauseForImages([(0,1), (0,2)]) == '(TableNumber=0 AND ImageNumber IN (1,2))'
-    
+
     def test_UniqueObjectClause(self):
         self.setup_mysql()
         assert UniqueObjectClause() == 'ImageNumber,ObjectNumber'
         self.setup_sqlite()
         assert UniqueObjectClause() == 'TableNumber,ImageNumber,ObjectNumber'
-    
+
     def test_UniqueImageClause(self):
         self.setup_mysql()
         assert UniqueImageClause() == 'ImageNumber'
         self.setup_sqlite()
         assert UniqueImageClause() == 'TableNumber,ImageNumber'
-            
+
 
     #
     # Test class functions
@@ -95,7 +95,7 @@ class TestDBConnect(unittest.TestCase):
         assert len(self.db.connections)==0
         assert len(self.db.cursors)==0
         assert len(self.db.connectionInfo)==0
-        
+
         self.setup_sqlite()
         assert len(self.db.connections)==0
         assert len(self.db.cursors)==0
@@ -113,7 +113,7 @@ class TestDBConnect(unittest.TestCase):
         assert len(self.db.cursors)==0
         assert len(self.db.connectionInfo)==0
 
-        
+
     def test_Commit(self):
         self.setup_mysql()
         self.db.connect()
@@ -126,7 +126,7 @@ class TestDBConnect(unittest.TestCase):
         res = self.db.execute('SELECT id FROM temp_test WHERE id=1')
         assert res == [(1,)]
         self.db.execute('DROP TABLE temp_test')
-    
+
     def test_execute(self):
         self.setup_mysql()
         self.db.execute('SELECT %s FROM %s'%(self.p.image_id,self.p.image_table))
@@ -138,7 +138,7 @@ class TestDBConnect(unittest.TestCase):
         self.setup_mysql()
         obKey = self.db.GetObjectIDAtIndex(imKey=(1,), index=94)
         assert obKey==(1,94)
-        
+
         self.setup_sqlite()
         obKey = self.db.GetObjectIDAtIndex(imKey=(0,1), index=94)
         assert obKey==(0,1,94)
@@ -146,41 +146,41 @@ class TestDBConnect(unittest.TestCase):
     def test_GetPerImageObjectCounts(self):
         self.setup_mysql()
         self.db.GetPerImageObjectCounts()
-        
+
         self.setup_sqlite()
         self.db.GetPerImageObjectCounts()
-        
+
     def test_GetObjectCoords(self):
         self.setup_mysql()
         xy = self.db.GetObjectCoords((1,1))
         assert xy==(11.4818, 305.06400000000002)
-        
+        #does this need to be changed below now that we're dealing with 3D?? unsure of what is being tested
         self.setup_sqlite()
         xy = self.db.GetObjectCoords((0,1,1))
         assert xy==(11.4818, 305.06400000000002)
-        
+
     def test_GetObjectNear(self):
         self.setup_mysql()
         obKey = self.db.GetObjectNear((1,), 11, 300)
         assert obKey == (1,1)
-        
+
         self.setup_sqlite()
         obKey = self.db.GetObjectNear((0,1), 11, 300)
         assert obKey == (0,1,1)
-        
+
     def test_GetFullChannelPathsForImage(self):
         self.setup_mysql()
         paths = self.db.GetFullChannelPathsForImage((1,))
-        assert paths==['2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d2.DIB', 
-                       '2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d1.DIB', 
+        assert paths==['2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d2.DIB',
+                       '2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d1.DIB',
                        '2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d0.DIB']
-        
+
         self.setup_sqlite()
         paths = self.db.GetFullChannelPathsForImage((0,1))
-        assert paths==['2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d2.DIB', 
-                       '2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d1.DIB', 
+        assert paths==['2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d2.DIB',
+                       '2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d1.DIB',
                        '2006_02_15_NIRHT/trcHT29Images/NIRHTa+001/AS_09125_050116000001_A01f00d0.DIB']
-        
+
     def test_GetGroupMaps(self):
         self.setup_mysql()
         groupMaps, colNames = self.db.GetGroupMaps()
@@ -188,12 +188,12 @@ class TestDBConnect(unittest.TestCase):
         assert groupMaps['Well'][(1,)] == (1,)
         assert groupMaps['Well+Gene'][(1,)] == (1, 'Gabra3')
         assert colNames == {'Gene': ['gene'], 'Well': ['well'], 'Well+Gene': ['well', 'gene']}
-        
+
         self.setup_sqlite()
         groupMaps, colNames = self.db.GetGroupMaps()
         assert groupMaps['96x4'][(0,1)] == (0,1)
         assert colNames == {'96x4': ['T2', 'I2']}
-        
+
     def test_GetFilteredImages(self):
         self.setup_mysql()
         test = set(self.db.GetFilteredImages('MAPs'))
@@ -201,22 +201,22 @@ class TestDBConnect(unittest.TestCase):
         vals = set([(239,), (21,), (32,), (197,), (86,), (23,), (61,), (72,), (213,), (222,), (63,), (229,), (221,), (38,), (224,), (231,), (13,), (24,), (78,), (214,), (15,), (223,), (53,), (64,), (246,), (55,), (93,), (232,), (30,), (206,), (95,), (215,), (5,), (16,), (70,), (7,), (45,), (56,), (238,), (198,), (47,), (207,), (85,), (96,), (22,), (87,), (253,), (8,), (62,), (254,), (255,), (199,), (37,), (48,), (205,), (230,), (208,), (39,), (77,), (88,), (14,), (79,), (245,), (256,), (54,), (247,), (29,), (40,), (94,), (31,), (240,), (69,), (80,), (6,), (216,), (71,), (237,), (248,), (200,), (46,)])
         assert test == vals
         assert self.db.GetFilteredImages('IMPOSSIBLE') == []
-        
+
         self.setup_sqlite()
         assert self.db.GetFilteredImages('FirstTen') == [(0,1),(0,2),(0,3),(0,4),(0,5),(0,6),(0,7),(0,8),(0,9),(0,10)]
         assert self.db.GetFilteredImages('IMPOSSIBLE') == []
-        
+
     def test_GetColumnNames(self):
         self.setup_mysql()
         cols = self.db.GetColumnNames(self.p.object_table)
         assert cols[:19] == ['ImageNumber', 'ObjectNumber', 'Nuclei_Location_CenterX', 'Nuclei_Location_CenterY', 'Nuclei_Children_Cells_Count', 'Nuclei_Correlation_Correlation_DNA_and_pH3', 'Nuclei_Correlation_Correlation_DNA_and_Actin', 'Nuclei_Correlation_Correlation_pH3_and_Actin', 'Nuclei_AreaShape_Area', 'Nuclei_AreaShape_Eccentricity', 'Nuclei_AreaShape_Solidity', 'Nuclei_AreaShape_Extent', 'Nuclei_AreaShape_Euler_number', 'Nuclei_AreaShape_Perimeter', 'Nuclei_AreaShape_Form_factor', 'Nuclei_AreaShape_MajorAxisLength', 'Nuclei_AreaShape_MinorAxisLength', 'Nuclei_AreaShape_Orientation', 'Nuclei_AreaShape_Zernike0_0']
         assert cols[-20:] == ['AreaNormalized_Cytoplasm_AreaShape_Zernike5_3', 'AreaNormalized_Cytoplasm_AreaShape_Zernike5_5', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_0', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_2', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_4', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_6', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_1', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_3', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_5', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_7', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_0', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_2', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_4', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_6', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_8', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_1', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_3', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_5', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_7', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_9']
-        
+
         self.setup_sqlite()
         cols = self.db.GetColumnNames(self.p.object_table)
         assert cols[:20] == ['TableNumber', 'ImageNumber', 'ObjectNumber', 'Nuclei_Location_CenterX', 'Nuclei_Location_CenterY', 'Nuclei_Children_Cells_Count', 'Nuclei_Correlation_Correlation_DNA_and_pH3', 'Nuclei_Correlation_Correlation_DNA_and_Actin', 'Nuclei_Correlation_Correlation_pH3_and_Actin', 'Nuclei_AreaShape_Area', 'Nuclei_AreaShape_Eccentricity', 'Nuclei_AreaShape_Solidity', 'Nuclei_AreaShape_Extent', 'Nuclei_AreaShape_Euler_number', 'Nuclei_AreaShape_Perimeter', 'Nuclei_AreaShape_Form_factor', 'Nuclei_AreaShape_MajorAxisLength', 'Nuclei_AreaShape_MinorAxisLength', 'Nuclei_AreaShape_Orientation', 'Nuclei_AreaShape_Zernike0_0']
         assert cols[-20:] == ['AreaNormalized_Cytoplasm_AreaShape_Zernike5_3', 'AreaNormalized_Cytoplasm_AreaShape_Zernike5_5', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_0', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_2', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_4', 'AreaNormalized_Cytoplasm_AreaShape_Zernike6_6', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_1', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_3', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_5', 'AreaNormalized_Cytoplasm_AreaShape_Zernike7_7', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_0', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_2', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_4', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_6', 'AreaNormalized_Cytoplasm_AreaShape_Zernike8_8', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_1', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_3', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_5', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_7', 'AreaNormalized_Cytoplasm_AreaShape_Zernike9_9']
-        
+
     def test_GetColumnTypes(self):
         self.setup_mysql()
         cols = self.db.GetColumnTypes(self.p.object_table)
@@ -224,19 +224,19 @@ class TestDBConnect(unittest.TestCase):
         assert cols[-20:] == [float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float, float]
         cols = self.db.GetColumnTypes(self.p.image_table)
         assert cols[:20] == [int, int, int, str, int, str, str, str, str, str, str, float, float, float, float, float, float, float, float, float]
-        
-        
+
+
     def test_GetColnamesForClassifier(self):
         self.setup_mysql()
         cols = self.db.GetColnamesForClassifier()
         for c in ['ImageNumber', 'ObjectNumber', 'Nuclei_Location_CenterX', 'Nuclei_Location_CenterY']:
             assert c not in cols
-        
+
         self.setup_sqlite()
         cols = self.db.GetColnamesForClassifier()
         for c in ['TableNumber', 'ImageNumber', 'ObjectNumber', 'Nuclei_Location_CenterX', 'Nuclei_Location_CenterY']:
             assert c not in cols
-                     
+
     def test_ReadExportToDB(self):
         '''Test reading data from Export to Database.'''
         self.setup_sqlite2()
@@ -245,7 +245,7 @@ class TestDBConnect(unittest.TestCase):
         assert len(self.db.GetAllImageKeys())==20
         assert self.db.GetAllImageKeys() == vals
         assert self.db.GetGroupMaps(True) == groups
-        
+
     def test_CreateMySQLTempTableFromData(self):
         self.setup_mysql()
         data = [['A01', 1, 1.],
@@ -260,7 +260,7 @@ class TestDBConnect(unittest.TestCase):
         self.db.CreateTableFromData(data, colnames, '__test_table', temporary=True)
         res =  self.db.execute('select * from __test_table')
         assert res==[('A01', 1, 1.0), ('A02', 1, 2.0), ('A03', 1, None), ('A04', 1, None), ('A04', 1, None), ('A04', 1, 100.0), ('A04', 1, 200.0)]
-        
+
     def test_CreateSQLiteTempTableFromData(self):
         self.setup_sqlite()
         data = [['A01', 1, 1.],
@@ -275,7 +275,7 @@ class TestDBConnect(unittest.TestCase):
         self.db.CreateTableFromData(data, colnames, '__test_table', temporary=True)
         res =  self.db.execute('select * from __test_table')
         assert res==[('A01', 1, 1.0), ('A02', 1, 2.0), ('A03', 1, None), ('A04', 1, None), ('A04', 1, None), ('A04', 1, 100.0), ('A04', 1, 200.0)]
-    
-        
+
+
 if __name__ == '__main__':
-    unittest.main()        
+    unittest.main()

--- a/cpa/tests/testdbconnect.py
+++ b/cpa/tests/testdbconnect.py
@@ -154,7 +154,6 @@ class TestDBConnect(unittest.TestCase):
         self.setup_mysql()
         xy = self.db.GetObjectCoords((1,1))
         assert xy==(11.4818, 305.06400000000002)
-        #does this need to be changed below now that we're dealing with 3D?? unsure of what is being tested
         self.setup_sqlite()
         xy = self.db.GetObjectCoords((0,1,1))
         assert xy==(11.4818, 305.06400000000002)

--- a/cpa/tilecollection.py
+++ b/cpa/tilecollection.py
@@ -63,7 +63,7 @@ class TileCollection(metaclass=Singleton):
         self.loader = TileLoader(self, None)
 
     def GetTileData(self, obKey, notify_window, priority=1):
-        return self.GetTiles([obKey], notify_window, priority)[0]
+        return self.GetTiles([obKey], notify_window, priority, processStack=p.process_3D)[0]
 
     def GetTiles(self, obKeys, notify_window, priority=1, display_whole_image=False, processStack=False):
         '''
@@ -75,7 +75,6 @@ class TileCollection(metaclass=Singleton):
         Returns: a list of lists of tile data (in numpy arrays) in the order
             of the obKeys that were passed in.
         '''
-        processStack=True
         if notify_window not in self.loader.notify_window:
             self.loader.notify_window.append(notify_window)
         self.group_priority -= 1
@@ -183,7 +182,6 @@ class TileLoader(threading.Thread):
 
                     # Get the tile
                     new_data = imagetools.FetchTile(obKey, display_whole_image=display_whole_image)
-                    #new_data=None
                     if new_data is None:
                         #if fetching fails, leave the tile blank
                         continue

--- a/cpa/tilecollection.py
+++ b/cpa/tilecollection.py
@@ -86,12 +86,10 @@ class TileCollection(metaclass=Singleton):
             for order, obKey in enumerate(obKeys):
                 if not obKey in self.tileData:
                     if obKey[0] in seen and not processStack:
-                        print("processing together")
                         # An item in the queue had the same source image, process them together.
                         # Heapqueue and the inbuilt cache will allow us to only load the source image once.
                         heappush(self.loadq, ((priority, seen[obKey[0]], order), obKey, display_whole_image))
                     else:
-                        print("processing separate")
                         heappush(self.loadq, ((priority, self.group_priority, order), obKey, display_whole_image))
                         seen[obKey[0]] = self.group_priority
                         self.group_priority += 1


### PR DESCRIPTION
Fixes #310 by allowing visualization of image stacks depending on the mid-point of a particular object or image in z. 
Changed classifier, image gallery, and image reading/tile fetching functions to allow 3D images to be read with a specific z plane depending on the midpoint of an object or image in z. 

Tested w/ 2D (translocation) and 3D (monolayer) datasets. 

This pull request is more up to date than #312 (I couldn't change this because a collaborator may need to use that specific version). Specifically, this PR fixes issues with Image Gallery that were present in #312. To my knowledge, there aren't further bugs that need squashing in this version. 