### PR TITLE
Fix scoring with loaded model

### DIFF
--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -1256,6 +1256,10 @@ class Classifier(wx.Frame):
                     bin.trained = True
                 self.scoreAllBtn.Enable()
                 self.scoreImageBtn.Enable()
+                # Create an empty training set as a placeholder.
+                self.trainingSet = TrainingSet(p)
+                self.trainingSet.Create([bin.label for bin in self.classBins],
+                                        [[] for _ in self.classBins])
                 self.algorithm.trained = True
                 self.PostMessage('Classifier model successfully loaded')
 


### PR DESCRIPTION
CPA failed to run scoring functions after loading a saved model. We needed to create a blank training set for some of the utility functions to work.