### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
         "seaborn>=0.11.1",
         "tifffile>=2021.3.31",
         "verlib==0.1",
-        "wxPython==4.1.0",
+        "wxPython==4.2.0",
     ],
     license="BSD",
     name="CellProfiler-Analyst",


### PR DESCRIPTION
For people installing CPA from source, wxpython 4.1.0 doesn't have a wheel for arm macs, 4.2.0 does.