### PR TITLE
Fix broken image scoring

### DIFF
--- a/cpa/classifier.py
+++ b/cpa/classifier.py
@@ -1671,12 +1671,12 @@ class Classifier(wx.Frame):
         for className, obKeys in classHits.items():
             training_keys = [key for key in obKeys if key in training_obKeys]
             if training_keys:
-                trainingCoords['training ' + className] = db.GetObjectsCoords(training_keys)[0:2]
+                trainingCoords['training ' + className] = db.GetObjectsCoords(training_keys)
             else:
                 trainingCoords['training ' + className] = []
             object_keys = [key for key in obKeys if key not in training_obKeys]
             if object_keys:
-                classCoords[className] = db.GetObjectsCoords(object_keys)[0:2]
+                classCoords[className] = db.GetObjectsCoords(object_keys)
             else:
                 classCoords[className] = []
         classCoords.update(trainingCoords)

--- a/cpa/dbconnect.py
+++ b/cpa/dbconnect.py
@@ -707,20 +707,10 @@ class DBConnect(metaclass=Singleton):
             return res[0]
 
     def GetObjectsCoords(self, obKeys, none_ok=False, silent=False):
-        '''Returns the specified objects' x, y, (and sometimes) z coordinates in an image.
-        '''
-        if p.process_3D:
-            res = self.execute('SELECT %s, %s, %s, %s, %s FROM %s WHERE %s'%(
-                        p.image_id, p.object_id, p.cell_x_loc, p.cell_y_loc, p.cell_z_loc, p.object_table,
-                        GetWhereClauseForObjects(obKeys)), silent=silent)
-            reslist = [list(coord) for coord in res] #tuples are immutable so first make tuple of tuples a list of lists
-            reslist[0][2]=round(reslist[0][2]) #round to get z slice
-            restup = [tuple(coord) for coord in reslist] #then convert back to list of tuples
-            res = tuple(restup) #convert to tuple of tuples
-        else:
-            res = self.execute('SELECT %s, %s, %s, %s FROM %s WHERE %s'%(
-                        p.image_id, p.object_id, p.cell_x_loc, p.cell_y_loc, p.object_table,
-                        GetWhereClauseForObjects(obKeys)), silent=silent)
+        # Returns the specified objects' x and y coordinates in an image.
+        res = self.execute('SELECT %s, %s, %s, %s FROM %s WHERE %s'%(
+                    p.image_id, p.object_id, p.cell_x_loc, p.cell_y_loc, p.object_table,
+                    GetWhereClauseForObjects(obKeys)), silent=silent)
         if len(res) == 0 or res[0][0] is None or res[0][1] is None:
             message = ('Failed to load coordinates for object key %s. This may '
                        'indicate a problem with your per-object table.\n'


### PR DESCRIPTION
Fixes #327 

Looks like something went wrong when implementing 3D mode, and the resulting coordinates list to draw onto images was being clipped to the first two elements.

`GetObjectsCoords` should only ever return 2D coordinates for objects as they're being mapped onto images. It appears that an attempt was made to have it return 3D, but this was only applied to the query portion rather than the downstream data processing. The attempt to round the third coordinate also doesn't appear to work as intended, though this isn't necessary anyway.

To resolve this I've stripped that part of the function out. If 3D mode does need to show position in 3D then feel free to restore, though I can't see anything trying this in the code.